### PR TITLE
More dsl with size types

### DIFF
--- a/anvil-appcompat-v7/src/main/kotlin/dev/inkremental/dsl/androidx/appcompat/AppCompatv7Setter.kt
+++ b/anvil-appcompat-v7/src/main/kotlin/dev/inkremental/dsl/androidx/appcompat/AppCompatv7Setter.kt
@@ -313,11 +313,11 @@ object AppCompatv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "overflowIcon" -> when {
       v is ActionMenuView && arg is Drawable? -> {
-        v.setOverflowIcon(arg as Drawable)
+        v.setOverflowIcon(arg)
         true
       }
       v is Toolbar && arg is Drawable? -> {
-        v.setOverflowIcon(arg as Drawable)
+        v.setOverflowIcon(arg)
         true
       }
       else -> false
@@ -394,86 +394,86 @@ object AppCompatv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "supportBackgroundTintList" -> when {
       v is AppCompatAutoCompleteTextView && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       v is AppCompatButton && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       v is AppCompatCheckBox && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       v is AppCompatEditText && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       v is AppCompatImageButton && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       v is AppCompatImageView && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       v is AppCompatMultiAutoCompleteTextView && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       v is AppCompatRadioButton && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       v is AppCompatSpinner && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       v is AppCompatTextView && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       else -> false
     }
     "supportBackgroundTintMode" -> when {
       v is AppCompatAutoCompleteTextView && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       v is AppCompatButton && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       v is AppCompatCheckBox && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       v is AppCompatEditText && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       v is AppCompatImageButton && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       v is AppCompatImageView && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       v is AppCompatMultiAutoCompleteTextView && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       v is AppCompatRadioButton && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       v is AppCompatSpinner && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       v is AppCompatTextView && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       else -> false
@@ -487,44 +487,44 @@ object AppCompatv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "supportButtonTintList" -> when {
       v is AppCompatCheckBox && arg is ColorStateList? -> {
-        v.setSupportButtonTintList(arg as ColorStateList)
+        v.setSupportButtonTintList(arg)
         true
       }
       v is AppCompatRadioButton && arg is ColorStateList? -> {
-        v.setSupportButtonTintList(arg as ColorStateList)
+        v.setSupportButtonTintList(arg)
         true
       }
       else -> false
     }
     "supportButtonTintMode" -> when {
       v is AppCompatCheckBox && arg is PorterDuff.Mode? -> {
-        v.setSupportButtonTintMode(arg as PorterDuff.Mode)
+        v.setSupportButtonTintMode(arg)
         true
       }
       v is AppCompatRadioButton && arg is PorterDuff.Mode? -> {
-        v.setSupportButtonTintMode(arg as PorterDuff.Mode)
+        v.setSupportButtonTintMode(arg)
         true
       }
       else -> false
     }
     "supportImageTintList" -> when {
       v is AppCompatImageButton && arg is ColorStateList? -> {
-        v.setSupportImageTintList(arg as ColorStateList)
+        v.setSupportImageTintList(arg)
         true
       }
       v is AppCompatImageView && arg is ColorStateList? -> {
-        v.setSupportImageTintList(arg as ColorStateList)
+        v.setSupportImageTintList(arg)
         true
       }
       else -> false
     }
     "supportImageTintMode" -> when {
       v is AppCompatImageButton && arg is PorterDuff.Mode? -> {
-        v.setSupportImageTintMode(arg as PorterDuff.Mode)
+        v.setSupportImageTintMode(arg)
         true
       }
       v is AppCompatImageView && arg is PorterDuff.Mode? -> {
-        v.setSupportImageTintMode(arg as PorterDuff.Mode)
+        v.setSupportImageTintMode(arg)
         true
       }
       else -> false
@@ -538,14 +538,14 @@ object AppCompatv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "supportCompoundDrawablesTintList" -> when {
       v is AppCompatTextView && arg is ColorStateList? -> {
-        v.setSupportCompoundDrawablesTintList(arg as ColorStateList)
+        v.setSupportCompoundDrawablesTintList(arg)
         true
       }
       else -> false
     }
     "supportCompoundDrawablesTintMode" -> when {
       v is AppCompatTextView && arg is PorterDuff.Mode? -> {
-        v.setSupportCompoundDrawablesTintMode(arg as PorterDuff.Mode)
+        v.setSupportCompoundDrawablesTintMode(arg)
         true
       }
       else -> false
@@ -765,14 +765,14 @@ object AppCompatv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "thumbTintList" -> when {
       v is SwitchCompat && arg is ColorStateList? -> {
-        v.setThumbTintList(arg as ColorStateList)
+        v.setThumbTintList(arg)
         true
       }
       else -> false
     }
     "thumbTintMode" -> when {
       v is SwitchCompat && arg is PorterDuff.Mode? -> {
-        v.setThumbTintMode(arg as PorterDuff.Mode)
+        v.setThumbTintMode(arg)
         true
       }
       else -> false
@@ -793,21 +793,21 @@ object AppCompatv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "trackTintList" -> when {
       v is SwitchCompat && arg is ColorStateList? -> {
-        v.setTrackTintList(arg as ColorStateList)
+        v.setTrackTintList(arg)
         true
       }
       else -> false
     }
     "trackTintMode" -> when {
       v is SwitchCompat && arg is PorterDuff.Mode? -> {
-        v.setTrackTintMode(arg as PorterDuff.Mode)
+        v.setTrackTintMode(arg)
         true
       }
       else -> false
     }
     "collapseContentDescription" -> when {
       v is Toolbar && arg is CharSequence? -> {
-        v.setCollapseContentDescription(arg as CharSequence)
+        v.setCollapseContentDescription(arg)
         true
       }
       v is Toolbar && arg is Int -> {
@@ -818,7 +818,7 @@ object AppCompatv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "collapseIcon" -> when {
       v is Toolbar && arg is Drawable? -> {
-        v.setCollapseIcon(arg as Drawable)
+        v.setCollapseIcon(arg)
         true
       }
       v is Toolbar && arg is Int -> {
@@ -861,7 +861,7 @@ object AppCompatv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "navigationContentDescription" -> when {
       v is Toolbar && arg is CharSequence? -> {
-        v.setNavigationContentDescription(arg as CharSequence)
+        v.setNavigationContentDescription(arg)
         true
       }
       v is Toolbar && arg is Int -> {
@@ -872,7 +872,7 @@ object AppCompatv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "navigationIcon" -> when {
       v is Toolbar && arg is Drawable? -> {
-        v.setNavigationIcon(arg as Drawable)
+        v.setNavigationIcon(arg)
         true
       }
       v is Toolbar && arg is Int -> {

--- a/anvil-cardview-v7/build.gradle.kts
+++ b/anvil-cardview-v7/build.gradle.kts
@@ -15,6 +15,14 @@ inkremental {
 		camelCaseName = "CardViewv7"
         srcPackage = "androidx.cardview"
         modulePackage = "dev.inkremental.dsl.androidx.cardview"
+		manualSetterName = "CustomCardViewv7Setter"
+		quirks = mutableMapOf(
+				"androidx.cardview.widget.CardView" to mapOf(
+						"setCardElevation" to false,
+						"setMaxCardElevation" to false,
+						"setRadius" to false
+				)
+		)
 	}
 }
 

--- a/anvil-cardview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/cardview/CardViewv7Setter.kt
+++ b/anvil-cardview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/cardview/CardViewv7Setter.kt
@@ -8,7 +8,6 @@ import androidx.cardview.widget.CardView
 import dev.inkremental.Inkremental
 import kotlin.Any
 import kotlin.Boolean
-import kotlin.Float
 import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
@@ -29,7 +28,7 @@ object CardViewv7Setter : Inkremental.AttributeSetter<Any> {
   ): Boolean = when (name) {
     "cardBackgroundColor" -> when {
       v is CardView && arg is ColorStateList? -> {
-        v.setCardBackgroundColor(arg as ColorStateList)
+        v.setCardBackgroundColor(arg)
         true
       }
       v is CardView && arg is Int -> {
@@ -38,30 +37,9 @@ object CardViewv7Setter : Inkremental.AttributeSetter<Any> {
       }
       else -> false
     }
-    "cardElevation" -> when {
-      v is CardView && arg is Float -> {
-        v.setCardElevation(arg)
-        true
-      }
-      else -> false
-    }
-    "maxCardElevation" -> when {
-      v is CardView && arg is Float -> {
-        v.setMaxCardElevation(arg)
-        true
-      }
-      else -> false
-    }
     "preventCornerOverlap" -> when {
       v is CardView && arg is Boolean -> {
         v.setPreventCornerOverlap(arg)
-        true
-      }
-      else -> false
-    }
-    "radius" -> when {
-      v is CardView && arg is Float -> {
-        v.setRadius(arg)
         true
       }
       else -> false

--- a/anvil-cardview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/cardview/CustomCardViewv7Setter.kt
+++ b/anvil-cardview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/cardview/CustomCardViewv7Setter.kt
@@ -1,0 +1,40 @@
+package dev.inkremental.dsl.androidx.cardview
+
+import android.view.View
+import androidx.cardview.widget.CardView
+import dev.inkremental.Inkremental
+import dev.inkremental.attr
+import dev.inkremental.dip
+import dev.inkremental.dsl.android.Dip
+import dev.inkremental.dsl.androidx.cardview.widget.CardViewScope
+
+fun CardViewScope.cardElevation(arg: Dip): Unit = attr("cardElevation", arg.value)
+fun CardViewScope.maxCardElevation(arg: Dip): Unit = attr("maxCardElevation", arg.value)
+fun CardViewScope.radius(arg: Dip): Unit = attr("radius", arg.value)
+
+object CustomCardViewv7Setter : Inkremental.AttributeSetter<Any> {
+    override fun set(v: View, name: String, value: Any?, prevValue: Any?): Boolean = when(name) {
+        "cardElevation" -> when {
+            v is CardView && value is Int -> {
+                v.cardElevation = dip(value).toFloat()
+                true
+            }
+            else -> false
+        }
+        "maxCardElevation" -> when {
+            v is CardView && value is Int -> {
+                v.maxCardElevation = dip(value).toFloat()
+                true
+            }
+            else -> false
+        }
+        "radius" -> when {
+            v is CardView && value is Int -> {
+                v.radius = dip(value).toFloat()
+                true
+            }
+            else -> false
+        }
+        else -> false
+    }
+}

--- a/anvil-cardview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/cardview/widget/CardView.kt
+++ b/anvil-cardview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/cardview/widget/CardView.kt
@@ -9,9 +9,9 @@ import dev.inkremental.attr
 import dev.inkremental.bind
 import dev.inkremental.dsl.android.widget.FrameLayoutScope
 import dev.inkremental.dsl.androidx.cardview.CardViewv7Setter
+import dev.inkremental.dsl.androidx.cardview.CustomCardViewv7Setter
 import dev.inkremental.v
 import kotlin.Boolean
-import kotlin.Float
 import kotlin.Int
 import kotlin.Suppress
 import kotlin.Unit
@@ -20,14 +20,12 @@ fun cardView(configure: CardViewScope.() -> Unit = {}) = v<CardView>(configure.b
 abstract class CardViewScope : FrameLayoutScope() {
   fun cardBackgroundColor(arg: ColorStateList?): Unit = attr("cardBackgroundColor", arg)
   fun cardBackgroundColor(arg: Int): Unit = attr("cardBackgroundColor", arg)
-  fun cardElevation(arg: Float): Unit = attr("cardElevation", arg)
-  fun maxCardElevation(arg: Float): Unit = attr("maxCardElevation", arg)
   fun preventCornerOverlap(arg: Boolean): Unit = attr("preventCornerOverlap", arg)
-  fun radius(arg: Float): Unit = attr("radius", arg)
   fun useCompatPadding(arg: Boolean): Unit = attr("useCompatPadding", arg)
   companion object : CardViewScope() {
     init {
       Inkremental.registerAttributeSetter(CardViewv7Setter)
+      Inkremental.registerAttributeSetter(CustomCardViewv7Setter)
     }
   }
 }

--- a/anvil-design/build.gradle.kts
+++ b/anvil-design/build.gradle.kts
@@ -61,7 +61,10 @@ inkremental {
 				"setIconPadding:kotlin.Int" to false,
 				"setTextColor:android.content.res.ColorStateList" to false,
 				"setTitle:kotlin.CharSequence" to false
-			)
+			),
+				"com.google.android.material.floatingactionbutton.FloatingActionButton" to mapOf(
+						"setCompatElevation" to false
+				)
 		)
 	}
 }

--- a/anvil-design/src/main/kotlin/dev/inkremental/dsl/google/android/material/CustomMaterialSetter.kt
+++ b/anvil-design/src/main/kotlin/dev/inkremental/dsl/google/android/material/CustomMaterialSetter.kt
@@ -10,16 +10,22 @@ import androidx.annotation.RequiresApi
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.CollapsingToolbarLayout
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import dev.inkremental.dsl.android.view.ViewScope
 import dev.inkremental.dsl.google.android.material.appbar.AppBarLayoutScope
 import dev.inkremental.Inkremental
 import dev.inkremental.attr
+import dev.inkremental.dip
+import dev.inkremental.dsl.android.Dip
+import dev.inkremental.dsl.google.android.material.floatingactionbutton.FloatingActionButtonScope
 
 fun ViewScope.collapseMode(collapseMode: Int) = attr("collapseMode", collapseMode)
 fun ViewScope.scrollFlags(scrollFlags: Int) = attr("scrollFlags", scrollFlags)
 fun ViewScope.behavior(behavior: CoordinatorLayout.Behavior<*>) = attr("behavior", behavior)
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-fun AppBarLayoutScope.appBarElevation(elevation: Float) = attr("appBarElevation", elevation)
+fun AppBarLayoutScope.appBarElevation(elevation: Dip) = attr("appBarElevation", elevation.value)
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+fun FloatingActionButtonScope.compatElevation(arg: Dip): Unit = attr("compatElevation", arg.value)
 
 object CustomMaterialSetter : Inkremental.AttributeSetter<Any> {
     override fun set(v: View, name: String, value: Any?, prevValue: Any?): Boolean = when(name) {
@@ -45,12 +51,19 @@ object CustomMaterialSetter : Inkremental.AttributeSetter<Any> {
             else -> false
         }
         "appBarElevation" -> when {
-            v is AppBarLayout && value is Float -> {
+            v is AppBarLayout && value is Int -> {
                 if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                     v.stateListAnimator = StateListAnimator().apply {
-                        addState(IntArray(0), ObjectAnimator.ofFloat(v, "elevation", value))
+                        addState(IntArray(0), ObjectAnimator.ofFloat(v, "elevation", dip(value).toFloat()))
                     }
                 }
+                true
+            }
+            else -> false
+        }
+        "compatElevation" -> when {
+            v is FloatingActionButton && value is Int -> {
+                v.compatElevation = dip(value).toFloat()
                 true
             }
             else -> false

--- a/anvil-design/src/main/kotlin/dev/inkremental/dsl/google/android/material/MaterialSetter.kt
+++ b/anvil-design/src/main/kotlin/dev/inkremental/dsl/google/android/material/MaterialSetter.kt
@@ -116,14 +116,14 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "collapsedTitleTypeface" -> when {
       v is CollapsingToolbarLayout && arg is Typeface? -> {
-        v.setCollapsedTitleTypeface(arg as Typeface)
+        v.setCollapsedTitleTypeface(arg)
         true
       }
       else -> false
     }
     "contentScrim" -> when {
       v is CollapsingToolbarLayout && arg is Drawable? -> {
-        v.setContentScrim(arg as Drawable)
+        v.setContentScrim(arg)
         true
       }
       else -> false
@@ -200,7 +200,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "expandedTitleTypeface" -> when {
       v is CollapsingToolbarLayout && arg is Typeface? -> {
-        v.setExpandedTitleTypeface(arg as Typeface)
+        v.setExpandedTitleTypeface(arg)
         true
       }
       else -> false
@@ -228,7 +228,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "statusBarScrim" -> when {
       v is CollapsingToolbarLayout && arg is Drawable? -> {
-        v.setStatusBarScrim(arg as Drawable)
+        v.setStatusBarScrim(arg)
         true
       }
       else -> false
@@ -249,7 +249,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "title" -> when {
       v is CollapsingToolbarLayout && arg is CharSequence? -> {
-        v.setTitle(arg as CharSequence)
+        v.setTitle(arg)
         true
       }
       else -> false
@@ -263,7 +263,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "backgroundTint" -> when {
       v is BottomAppBar && arg is ColorStateList? -> {
-        v.setBackgroundTint(arg as ColorStateList)
+        v.setBackgroundTint(arg)
         true
       }
       else -> false
@@ -305,11 +305,11 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "itemBackground" -> when {
       v is BottomNavigationView && arg is Drawable? -> {
-        v.setItemBackground(arg as Drawable)
+        v.setItemBackground(arg)
         true
       }
       v is NavigationView && arg is Drawable? -> {
-        v.setItemBackground(arg as Drawable)
+        v.setItemBackground(arg)
         true
       }
       else -> false
@@ -348,11 +348,11 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "itemIconTintList" -> when {
       v is BottomNavigationView && arg is ColorStateList? -> {
-        v.setItemIconTintList(arg as ColorStateList)
+        v.setItemIconTintList(arg)
         true
       }
       v is NavigationView && arg is ColorStateList? -> {
-        v.setItemIconTintList(arg as ColorStateList)
+        v.setItemIconTintList(arg)
         true
       }
       else -> false
@@ -373,11 +373,11 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "itemTextColor" -> when {
       v is BottomNavigationView && arg is ColorStateList? -> {
-        v.setItemTextColor(arg as ColorStateList)
+        v.setItemTextColor(arg)
         true
       }
       v is NavigationView && arg is ColorStateList? -> {
-        v.setItemTextColor(arg as ColorStateList)
+        v.setItemTextColor(arg)
         true
       }
       else -> false
@@ -483,7 +483,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "iconTint" -> when {
       v is MaterialButton && arg is ColorStateList? -> {
-        v.setIconTint(arg as ColorStateList)
+        v.setIconTint(arg)
         true
       }
       else -> false
@@ -504,15 +504,15 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "rippleColor" -> when {
       v is MaterialButton && arg is ColorStateList? -> {
-        v.setRippleColor(arg as ColorStateList)
+        v.setRippleColor(arg)
         true
       }
       v is Chip && arg is ColorStateList? -> {
-        v.setRippleColor(arg as ColorStateList)
+        v.setRippleColor(arg)
         true
       }
       v is FloatingActionButton && arg is ColorStateList? -> {
-        v.setRippleColor(arg as ColorStateList)
+        v.setRippleColor(arg)
         true
       }
       v is FloatingActionButton && arg is Int -> {
@@ -534,7 +534,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "strokeColor" -> when {
       v is MaterialButton && arg is ColorStateList? -> {
-        v.setStrokeColor(arg as ColorStateList)
+        v.setStrokeColor(arg)
         true
       }
       v is MaterialCardView && arg is Int -> {
@@ -584,7 +584,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "checkedIcon" -> when {
       v is Chip && arg is Drawable? -> {
-        v.setCheckedIcon(arg as Drawable)
+        v.setCheckedIcon(arg)
         true
       }
       else -> false
@@ -609,7 +609,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "chipBackgroundColor" -> when {
       v is Chip && arg is ColorStateList? -> {
-        v.setChipBackgroundColor(arg as ColorStateList)
+        v.setChipBackgroundColor(arg)
         true
       }
       else -> false
@@ -658,7 +658,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "chipIcon" -> when {
       v is Chip && arg is Drawable? -> {
-        v.setChipIcon(arg as Drawable)
+        v.setChipIcon(arg)
         true
       }
       else -> false
@@ -686,7 +686,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "chipIconTint" -> when {
       v is Chip && arg is ColorStateList? -> {
-        v.setChipIconTint(arg as ColorStateList)
+        v.setChipIconTint(arg)
         true
       }
       else -> false
@@ -739,7 +739,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "chipStrokeColor" -> when {
       v is Chip && arg is ColorStateList? -> {
-        v.setChipStrokeColor(arg as ColorStateList)
+        v.setChipStrokeColor(arg)
         true
       }
       else -> false
@@ -767,14 +767,14 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "closeIcon" -> when {
       v is Chip && arg is Drawable? -> {
-        v.setCloseIcon(arg as Drawable)
+        v.setCloseIcon(arg)
         true
       }
       else -> false
     }
     "closeIconContentDescription" -> when {
       v is Chip && arg is CharSequence? -> {
-        v.setCloseIconContentDescription(arg as CharSequence)
+        v.setCloseIconContentDescription(arg)
         true
       }
       else -> false
@@ -830,7 +830,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "closeIconTint" -> when {
       v is Chip && arg is ColorStateList? -> {
-        v.setCloseIconTint(arg as ColorStateList)
+        v.setCloseIconTint(arg)
         true
       }
       else -> false
@@ -855,7 +855,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "hideMotionSpec" -> when {
       v is Chip && arg is MotionSpec? -> {
-        v.setHideMotionSpec(arg as MotionSpec)
+        v.setHideMotionSpec(arg)
         true
       }
       v is FloatingActionButton && arg is MotionSpec -> {
@@ -922,7 +922,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "showMotionSpec" -> when {
       v is Chip && arg is MotionSpec? -> {
-        v.setShowMotionSpec(arg as MotionSpec)
+        v.setShowMotionSpec(arg)
         true
       }
       v is FloatingActionButton && arg is MotionSpec -> {
@@ -944,7 +944,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "textAppearance" -> when {
       v is Chip && arg is TextAppearance? -> {
-        v.setTextAppearance(arg as TextAppearance)
+        v.setTextAppearance(arg)
         true
       }
       v is NavigationMenuItemView && arg is Int -> {
@@ -1071,23 +1071,23 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "circularRevealOverlayDrawable" -> when {
       v is CircularRevealFrameLayout && arg is Drawable? -> {
-        v.setCircularRevealOverlayDrawable(arg as Drawable)
+        v.setCircularRevealOverlayDrawable(arg)
         true
       }
       v is CircularRevealGridLayout && arg is Drawable? -> {
-        v.setCircularRevealOverlayDrawable(arg as Drawable)
+        v.setCircularRevealOverlayDrawable(arg)
         true
       }
       v is CircularRevealLinearLayout && arg is Drawable? -> {
-        v.setCircularRevealOverlayDrawable(arg as Drawable)
+        v.setCircularRevealOverlayDrawable(arg)
         true
       }
       v is CircularRevealRelativeLayout && arg is Drawable? -> {
-        v.setCircularRevealOverlayDrawable(arg as Drawable)
+        v.setCircularRevealOverlayDrawable(arg)
         true
       }
       v is CircularRevealCardView && arg is Drawable? -> {
-        v.setCircularRevealOverlayDrawable(arg as Drawable)
+        v.setCircularRevealOverlayDrawable(arg)
         true
       }
       else -> false
@@ -1117,30 +1117,23 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "revealInfo" -> when {
       v is CircularRevealFrameLayout && arg is CircularRevealWidget.RevealInfo? -> {
-        v.setRevealInfo(arg as CircularRevealWidget.RevealInfo)
+        v.setRevealInfo(arg)
         true
       }
       v is CircularRevealGridLayout && arg is CircularRevealWidget.RevealInfo? -> {
-        v.setRevealInfo(arg as CircularRevealWidget.RevealInfo)
+        v.setRevealInfo(arg)
         true
       }
       v is CircularRevealLinearLayout && arg is CircularRevealWidget.RevealInfo? -> {
-        v.setRevealInfo(arg as CircularRevealWidget.RevealInfo)
+        v.setRevealInfo(arg)
         true
       }
       v is CircularRevealRelativeLayout && arg is CircularRevealWidget.RevealInfo? -> {
-        v.setRevealInfo(arg as CircularRevealWidget.RevealInfo)
+        v.setRevealInfo(arg)
         true
       }
       v is CircularRevealCardView && arg is CircularRevealWidget.RevealInfo? -> {
-        v.setRevealInfo(arg as CircularRevealWidget.RevealInfo)
-        true
-      }
-      else -> false
-    }
-    "compatElevation" -> when {
-      v is FloatingActionButton && arg is Float -> {
-        v.setCompatElevation(arg)
+        v.setRevealInfo(arg)
         true
       }
       else -> false
@@ -1203,28 +1196,28 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "supportBackgroundTintList" -> when {
       v is FloatingActionButton && arg is ColorStateList? -> {
-        v.setSupportBackgroundTintList(arg as ColorStateList)
+        v.setSupportBackgroundTintList(arg)
         true
       }
       else -> false
     }
     "supportBackgroundTintMode" -> when {
       v is FloatingActionButton && arg is PorterDuff.Mode? -> {
-        v.setSupportBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setSupportBackgroundTintMode(arg)
         true
       }
       else -> false
     }
     "supportImageTintList" -> when {
       v is FloatingActionButton && arg is ColorStateList? -> {
-        v.setSupportImageTintList(arg as ColorStateList)
+        v.setSupportImageTintList(arg)
         true
       }
       else -> false
     }
     "supportImageTintMode" -> when {
       v is FloatingActionButton && arg is PorterDuff.Mode? -> {
-        v.setSupportImageTintMode(arg as PorterDuff.Mode)
+        v.setSupportImageTintMode(arg)
         true
       }
       else -> false
@@ -1298,7 +1291,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "navigationItemSelectedListener" -> when {
       v is NavigationView && arg is NavigationView.OnNavigationItemSelectedListener? -> {
-        v.setNavigationItemSelectedListener(arg as NavigationView.OnNavigationItemSelectedListener)
+        v.setNavigationItemSelectedListener(arg)
         true
       }
       else -> false
@@ -1319,7 +1312,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "selectedTabIndicator" -> when {
       v is TabLayout && arg is Drawable? -> {
-        v.setSelectedTabIndicator(arg as Drawable)
+        v.setSelectedTabIndicator(arg)
         true
       }
       v is TabLayout && arg is Int -> {
@@ -1351,7 +1344,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "tabIconTint" -> when {
       v is TabLayout && arg is ColorStateList? -> {
-        v.setTabIconTint(arg as ColorStateList)
+        v.setTabIconTint(arg)
         true
       }
       else -> false
@@ -1393,7 +1386,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "tabTextColors" -> when {
       v is TabLayout && arg is ColorStateList? -> {
-        v.setTabTextColors(arg as ColorStateList)
+        v.setTabTextColors(arg)
         true
       }
       else -> false
@@ -1456,14 +1449,14 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "defaultHintTextColor" -> when {
       v is TextInputLayout && arg is ColorStateList? -> {
-        v.setDefaultHintTextColor(arg as ColorStateList)
+        v.setDefaultHintTextColor(arg)
         true
       }
       else -> false
     }
     "error" -> when {
       v is TextInputLayout && arg is CharSequence? -> {
-        v.setError(arg as CharSequence)
+        v.setError(arg)
         true
       }
       else -> false
@@ -1484,21 +1477,21 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "errorTextColor" -> when {
       v is TextInputLayout && arg is ColorStateList? -> {
-        v.setErrorTextColor(arg as ColorStateList)
+        v.setErrorTextColor(arg)
         true
       }
       else -> false
     }
     "helperText" -> when {
       v is TextInputLayout && arg is CharSequence? -> {
-        v.setHelperText(arg as CharSequence)
+        v.setHelperText(arg)
         true
       }
       else -> false
     }
     "helperTextColor" -> when {
       v is TextInputLayout && arg is ColorStateList? -> {
-        v.setHelperTextColor(arg as ColorStateList)
+        v.setHelperTextColor(arg)
         true
       }
       else -> false
@@ -1519,7 +1512,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "hint" -> when {
       v is TextInputLayout && arg is CharSequence? -> {
-        v.setHint(arg as CharSequence)
+        v.setHint(arg)
         true
       }
       else -> false
@@ -1547,7 +1540,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "passwordVisibilityToggleContentDescription" -> when {
       v is TextInputLayout && arg is CharSequence? -> {
-        v.setPasswordVisibilityToggleContentDescription(arg as CharSequence)
+        v.setPasswordVisibilityToggleContentDescription(arg)
         true
       }
       v is TextInputLayout && arg is Int -> {
@@ -1558,7 +1551,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "passwordVisibilityToggleDrawable" -> when {
       v is TextInputLayout && arg is Drawable? -> {
-        v.setPasswordVisibilityToggleDrawable(arg as Drawable)
+        v.setPasswordVisibilityToggleDrawable(arg)
         true
       }
       v is TextInputLayout && arg is Int -> {
@@ -1576,14 +1569,14 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "passwordVisibilityToggleTintList" -> when {
       v is TextInputLayout && arg is ColorStateList? -> {
-        v.setPasswordVisibilityToggleTintList(arg as ColorStateList)
+        v.setPasswordVisibilityToggleTintList(arg)
         true
       }
       else -> false
     }
     "passwordVisibilityToggleTintMode" -> when {
       v is TextInputLayout && arg is PorterDuff.Mode? -> {
-        v.setPasswordVisibilityToggleTintMode(arg as PorterDuff.Mode)
+        v.setPasswordVisibilityToggleTintMode(arg)
         true
       }
       else -> false
@@ -1597,7 +1590,7 @@ object MaterialSetter : Inkremental.AttributeSetter<Any> {
     }
     "typeface" -> when {
       v is TextInputLayout && arg is Typeface? -> {
-        v.setTypeface(arg as Typeface)
+        v.setTypeface(arg)
         true
       }
       else -> false

--- a/anvil-design/src/main/kotlin/dev/inkremental/dsl/google/android/material/floatingactionbutton/FloatingActionButton.kt
+++ b/anvil-design/src/main/kotlin/dev/inkremental/dsl/google/android/material/floatingactionbutton/FloatingActionButton.kt
@@ -22,7 +22,6 @@ import kotlin.Unit
 fun floatingActionButton(configure: FloatingActionButtonScope.() -> Unit = {}) =
     v<FloatingActionButton>(configure.bind(FloatingActionButtonScope))
 abstract class FloatingActionButtonScope : VisibilityAwareImageButtonScope() {
-  fun compatElevation(arg: Float): Unit = attr("compatElevation", arg)
   fun compatElevationResource(arg: Int): Unit = attr("compatElevationResource", arg)
   fun compatHoveredFocusedTranslationZ(arg: Float): Unit = attr("compatHoveredFocusedTranslationZ",
       arg)

--- a/anvil-recyclerview-v7/build.gradle.kts
+++ b/anvil-recyclerview-v7/build.gradle.kts
@@ -16,6 +16,10 @@ inkremental {
         srcPackage = "androidx.recyclerview"
         modulePackage = "dev.inkremental.dsl.androidx.recyclerview"
 		manualSetterName = "CustomRecyclerViewv7Setter"
+		quirks = mutableMapOf(
+				"androidx.recyclerview.widget.RecyclerView" to mapOf(
+						"setAdapter" to false) //needs covariant in ViewHolder type, so we handle it
+		)
 	}
 }
 

--- a/anvil-recyclerview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/recyclerview/CustomRecyclerViewv7Setter.kt
+++ b/anvil-recyclerview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/recyclerview/CustomRecyclerViewv7Setter.kt
@@ -26,6 +26,8 @@ fun RecyclerViewScope.gridLayoutManager(
         LayoutManagerParams(orientation, reverseLayout, spanCount, spanSizeLookup)
     )
 
+fun RecyclerViewScope.adapter(arg: RecyclerView.Adapter<out RecyclerView.ViewHolder>?): Unit = attr("adapter", arg)
+
 object CustomRecyclerViewv7Setter : Inkremental.AttributeSetter<Any> {
     override fun set(v: View, name: String, value: Any?, prevValue: Any?): Boolean = when(name) {
         "linearLayoutManager" -> when {
@@ -43,8 +45,17 @@ object CustomRecyclerViewv7Setter : Inkremental.AttributeSetter<Any> {
                     value.orientation,
                     value.reverseLayout
                 ).also {
-                    it.spanSizeLookup = value.spanSizeLookup
+                    value.spanSizeLookup?.let { spanSizeLookup ->
+                        it.spanSizeLookup = spanSizeLookup
+                    }
                 }
+                true
+            }
+            else -> false
+        }
+        "adapter" -> when {
+            v is RecyclerView && value is RecyclerView.Adapter<*>? -> {
+                v.adapter = value
                 true
             }
             else -> false

--- a/anvil-recyclerview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/recyclerview/RecyclerViewv7Setter.kt
+++ b/anvil-recyclerview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/recyclerview/RecyclerViewv7Setter.kt
@@ -29,21 +29,14 @@ object RecyclerViewv7Setter : Inkremental.AttributeSetter<Any> {
   ): Boolean = when (name) {
     "accessibilityDelegateCompat" -> when {
       v is RecyclerView && arg is RecyclerViewAccessibilityDelegate? -> {
-        v.setAccessibilityDelegateCompat(arg as RecyclerViewAccessibilityDelegate)
-        true
-      }
-      else -> false
-    }
-    "adapter" -> when {
-      v is RecyclerView && arg is RecyclerView.Adapter<*>? -> {
-        v.setAdapter(arg as RecyclerView.Adapter<RecyclerView.ViewHolder>)
+        v.setAccessibilityDelegateCompat(arg)
         true
       }
       else -> false
     }
     "childDrawingOrderCallback" -> when {
       v is RecyclerView && arg is RecyclerView.ChildDrawingOrderCallback? -> {
-        v.setChildDrawingOrderCallback(arg as RecyclerView.ChildDrawingOrderCallback)
+        v.setChildDrawingOrderCallback(arg)
         true
       }
       else -> false
@@ -64,7 +57,7 @@ object RecyclerViewv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "itemAnimator" -> when {
       v is RecyclerView && arg is RecyclerView.ItemAnimator? -> {
-        v.setItemAnimator(arg as RecyclerView.ItemAnimator)
+        v.setItemAnimator(arg)
         true
       }
       else -> false
@@ -78,7 +71,7 @@ object RecyclerViewv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "layoutManager" -> when {
       v is RecyclerView && arg is RecyclerView.LayoutManager? -> {
-        v.setLayoutManager(arg as RecyclerView.LayoutManager)
+        v.setLayoutManager(arg)
         true
       }
       else -> false
@@ -110,14 +103,14 @@ object RecyclerViewv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "recycledViewPool" -> when {
       v is RecyclerView && arg is RecyclerView.RecycledViewPool? -> {
-        v.setRecycledViewPool(arg as RecyclerView.RecycledViewPool)
+        v.setRecycledViewPool(arg)
         true
       }
       else -> false
     }
     "recyclerListener" -> when {
       v is RecyclerView && arg is RecyclerView.RecyclerListener? -> {
-        v.setRecyclerListener(arg as RecyclerView.RecyclerListener)
+        v.setRecyclerListener(arg)
         true
       }
       else -> false
@@ -131,7 +124,7 @@ object RecyclerViewv7Setter : Inkremental.AttributeSetter<Any> {
     }
     "viewCacheExtension" -> when {
       v is RecyclerView && arg is RecyclerView.ViewCacheExtension? -> {
-        v.setViewCacheExtension(arg as RecyclerView.ViewCacheExtension)
+        v.setViewCacheExtension(arg)
         true
       }
       else -> false

--- a/anvil-recyclerview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/recyclerview/RenderableRecyclerViewAdapter.kt
+++ b/anvil-recyclerview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/recyclerview/RenderableRecyclerViewAdapter.kt
@@ -38,7 +38,7 @@ abstract class RenderableRecyclerViewAdapter : RecyclerView.Adapter<RenderableRe
 
     companion object {
         fun <T> withItems(items: List<T>,
-                          r: RenderableAdapter.Item<T>): RenderableRecyclerViewAdapter {
+                          r: (index: Int, item: T) -> Unit): RenderableRecyclerViewAdapter {
             return object : RenderableRecyclerViewAdapter() {
 
                 override fun getItemCount(): Int {
@@ -53,7 +53,7 @@ abstract class RenderableRecyclerViewAdapter : RecyclerView.Adapter<RenderableRe
                 override fun view(holder: RecyclerView.ViewHolder?) {
                     holder?.let {
                         val i = it.layoutPosition
-                        r.view(i, items[i])
+                        r(i, items[i])
                     }
                 }
 

--- a/anvil-recyclerview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/recyclerview/widget/RecyclerView.kt
+++ b/anvil-recyclerview-v7/src/main/kotlin/dev/inkremental/dsl/androidx/recyclerview/widget/RecyclerView.kt
@@ -21,7 +21,6 @@ fun recyclerView(configure: RecyclerViewScope.() -> Unit = {}) =
 abstract class RecyclerViewScope : ViewGroupScope() {
   fun accessibilityDelegateCompat(arg: RecyclerViewAccessibilityDelegate?): Unit =
       attr("accessibilityDelegateCompat", arg)
-  fun adapter(arg: RecyclerView.Adapter<RecyclerView.ViewHolder>?): Unit = attr("adapter", arg)
   fun childDrawingOrderCallback(arg: RecyclerView.ChildDrawingOrderCallback?): Unit =
       attr("childDrawingOrderCallback", arg)
   fun edgeEffectFactory(arg: RecyclerView.EdgeEffectFactory): Unit = attr("edgeEffectFactory", arg)

--- a/anvil-support-v4/src/main/kotlin/dev/inkremental/dsl/androidx/core/SupportCoreUiSetter.kt
+++ b/anvil-support-v4/src/main/kotlin/dev/inkremental/dsl/androidx/core/SupportCoreUiSetter.kt
@@ -40,11 +40,11 @@ object SupportCoreUiSetter : Inkremental.AttributeSetter<Any> {
   ): Boolean = when (name) {
     "statusBarBackground" -> when {
       v is CoordinatorLayout && arg is Drawable? -> {
-        v.setStatusBarBackground(arg as Drawable)
+        v.setStatusBarBackground(arg)
         true
       }
       v is DrawerLayout && arg is Drawable? -> {
-        v.setStatusBarBackground(arg as Drawable)
+        v.setStatusBarBackground(arg)
         true
       }
       v is DrawerLayout && arg is Int -> {
@@ -115,7 +115,7 @@ object SupportCoreUiSetter : Inkremental.AttributeSetter<Any> {
     }
     "panelSlideListener" -> when {
       v is SlidingPaneLayout && arg is SlidingPaneLayout.PanelSlideListener? -> {
-        v.setPanelSlideListener(arg as SlidingPaneLayout.PanelSlideListener)
+        v.setPanelSlideListener(arg)
         true
       }
       else -> false
@@ -129,14 +129,14 @@ object SupportCoreUiSetter : Inkremental.AttributeSetter<Any> {
     }
     "shadowDrawableLeft" -> when {
       v is SlidingPaneLayout && arg is Drawable? -> {
-        v.setShadowDrawableLeft(arg as Drawable)
+        v.setShadowDrawableLeft(arg)
         true
       }
       else -> false
     }
     "shadowDrawableRight" -> when {
       v is SlidingPaneLayout && arg is Drawable? -> {
-        v.setShadowDrawableRight(arg as Drawable)
+        v.setShadowDrawableRight(arg)
         true
       }
       else -> false
@@ -185,7 +185,7 @@ object SupportCoreUiSetter : Inkremental.AttributeSetter<Any> {
     }
     "onChildScrollUpCallback" -> when {
       v is SwipeRefreshLayout && arg is SwipeRefreshLayout.OnChildScrollUpCallback? -> {
-        v.setOnChildScrollUpCallback(arg as SwipeRefreshLayout.OnChildScrollUpCallback)
+        v.setOnChildScrollUpCallback(arg)
         true
       }
       else -> false
@@ -321,7 +321,7 @@ object SupportCoreUiSetter : Inkremental.AttributeSetter<Any> {
     }
     "pageMarginDrawable" -> when {
       v is ViewPager && arg is Drawable? -> {
-        v.setPageMarginDrawable(arg as Drawable)
+        v.setPageMarginDrawable(arg)
         true
       }
       v is ViewPager && arg is Int -> {

--- a/anvil/build.gradle.kts
+++ b/anvil/build.gradle.kts
@@ -54,11 +54,17 @@ inkremental {
 			"android.widget.TextView" to mapOf(
 				"setText:kotlin.CharSequence" to false,
 				"setTextSize" to false, // broken: uses "sp" unit by default
-				"setInputExtras" to false
+				"setInputExtras" to false,
+				"setMinWidth" to false	// we handle it
+			),
+			// Exception must be checked in this attribute setter
+			"android.view.View" to mapOf(
+				"setElevation" to false // we handle it
 			),
 
 			"android.widget.Switch" to mapOf(
-				"__viewAlias" to "SwitchView"
+				"__viewAlias" to "SwitchView",
+				"setSwitchMinWidth" to false	// we handle it
 			),
 
 			// This will remove the whole builder, so no factory method will be generated

--- a/anvil/src/main/kotlin/dev/inkremental/RenderableAdapter.kt
+++ b/anvil/src/main/kotlin/dev/inkremental/RenderableAdapter.kt
@@ -9,10 +9,6 @@ import dev.inkremental.Inkremental.Mount
 abstract class RenderableAdapter : BaseAdapter() {
     private var currentPosition = -1
 
-    interface Item<T> {
-        fun view(index: Int, item: T)
-    }
-
     override fun getView(pos: Int, convertView: View?, parent: ViewGroup): View {
         var v = convertView
         if (v == null) {
@@ -37,7 +33,7 @@ abstract class RenderableAdapter : BaseAdapter() {
     abstract fun view(index: Int)
 
     companion object {
-        fun <T> withItems(items: List<T>, r: Item<T>): RenderableAdapter {
+        fun <T> withItems(items: List<T>, r : (index: Int, item: T) -> Unit): RenderableAdapter {
             return object : RenderableAdapter() {
                 override fun getCount(): Int {
                     return items.size
@@ -48,7 +44,7 @@ abstract class RenderableAdapter : BaseAdapter() {
                 }
 
                 override fun view(pos: Int) {
-                    r.view(pos, getItem(pos))
+                    r(pos, getItem(pos))
                 }
             }
         }

--- a/anvil/src/main/kotlin/dev/inkremental/dsl/android/CustomSdkSetter.kt
+++ b/anvil/src/main/kotlin/dev/inkremental/dsl/android/CustomSdkSetter.kt
@@ -6,11 +6,13 @@ import android.animation.Animator
 import android.animation.AnimatorSet
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.TypedValue
 import android.view.*
 import android.widget.*
+import androidx.annotation.RequiresApi
 import dev.inkremental.Inkremental
 import dev.inkremental.attr
 import dev.inkremental.dip
@@ -102,6 +104,8 @@ fun RadioGroupScope.check(id: Int) = attr("check", id)
 
 fun ViewScope.weight(weight: Float) = attr("weight", weight)
 fun ViewScope.layoutGravity(gravity: Int) = attr("layoutGravity", gravity)
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+fun ViewScope.elevate(arg: Dip): Unit = attr("elevation", arg.value)
 
 typealias SeekBarChangeListener = (seekBar: SeekBar, progress: Int, fromUser: Boolean) -> Unit
 fun SeekBarScope.onSeekBarChange(listener: SeekBarChangeListener) = attr("onSeekBarChange", listener)
@@ -114,6 +118,9 @@ fun TextViewScope.text(text: CharSequence?) = attr("text", text)
 fun TextViewScope.onTextChanged(watcher: (CharSequence) -> Unit) = attr("onTextChanged", watcher)
 fun TextViewScope.onTextChanged(watcher: TextWatcher) = attr("onTextChanged", watcher)
 fun TextViewScope.inputExtras(extras: Int) = attr("inputExtras", extras)
+fun TextViewScope.minWidth(arg: Dip): Unit = attr("minWidth", arg.value)
+
+fun SwitchViewScope.switchMinWidth(arg: Dip): Unit = attr("switchMinWidth", arg.value)
 
 object CustomSdkSetter : Inkremental.AttributeSetter<Any> {
     override fun set(v: View, name: String, value: Any?, prevValue: Any?): Boolean = when (name) {
@@ -397,6 +404,27 @@ object CustomSdkSetter : Inkremental.AttributeSetter<Any> {
                     e.printStackTrace()
                     false
                 }
+            }
+            else -> false
+        }
+        "minWidth" -> when {
+            v is TextView && value is Int -> {
+                v.minWidth = dip(value)
+                true
+            }
+            else -> false
+        }
+        "switchMinWidth" -> when {
+            v is Switch && value is Int -> {
+                v.switchMinWidth = dip(value)
+                true
+            }
+            else -> false
+        }
+        "elevation" -> when {
+            value is Int -> {
+                v.elevation = dip(value).toFloat()
+                true
             }
             else -> false
         }

--- a/anvil/src/sdk17/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
+++ b/anvil/src/sdk17/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
@@ -474,7 +474,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "accessibilityDelegate" -> when {
       arg is View.AccessibilityDelegate? -> {
-        v.setAccessibilityDelegate(arg as View.AccessibilityDelegate)
+        v.setAccessibilityDelegate(arg)
         true
       }
       else -> false
@@ -684,7 +684,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "layerPaint" -> when {
       arg is Paint? -> {
-        v.setLayerPaint(arg as Paint)
+        v.setLayerPaint(arg)
         true
       }
       else -> false
@@ -2003,7 +2003,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "checkMarkDrawable" -> when {
       v is CheckedTextView && arg is Drawable? -> {
-        v.setCheckMarkDrawable(arg as Drawable)
+        v.setCheckMarkDrawable(arg)
         true
       }
       v is CheckedTextView && arg is Int -> {
@@ -2056,7 +2056,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "buttonDrawable" -> when {
       v is CompoundButton && arg is Drawable? -> {
-        v.setButtonDrawable(arg as Drawable)
+        v.setButtonDrawable(arg)
         true
       }
       v is CompoundButton && arg is Int -> {
@@ -2430,7 +2430,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
         true
       }
       v is ImageView && arg is Drawable? -> {
-        v.setImageDrawable(arg as Drawable)
+        v.setImageDrawable(arg)
         true
       }
       else -> false
@@ -2452,7 +2452,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
         true
       }
       v is ImageView && arg is Uri? -> {
-        v.setImageURI(arg as Uri)
+        v.setImageURI(arg)
         true
       }
       else -> false
@@ -2634,7 +2634,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "divider" -> when {
       v is ListView && arg is Drawable? -> {
-        v.setDivider(arg as Drawable)
+        v.setDivider(arg)
         true
       }
       else -> false
@@ -2704,7 +2704,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "displayedValues" -> when {
       v is NumberPicker && arg is Array<*> -> {
-        v.setDisplayedValues(arg as Array<String>)
+        v.setDisplayedValues(arg as? Array<String>)
         true
       }
       else -> false
@@ -2823,7 +2823,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "excludeMimes" -> when {
       v is QuickContactBadge && arg is Array<*> -> {
-        v.setExcludeMimes(arg as Array<String>)
+        v.setExcludeMimes(arg as? Array<String>)
         true
       }
       else -> false
@@ -3013,7 +3013,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "queryHint" -> when {
       v is SearchView && arg is CharSequence? -> {
-        v.setQueryHint(arg as CharSequence)
+        v.setQueryHint(arg)
         true
       }
       else -> false
@@ -3153,13 +3153,6 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
       }
       else -> false
     }
-    "switchMinWidth" -> when {
-      v is Switch && arg is Int -> {
-        v.setSwitchMinWidth(arg)
-        true
-      }
-      else -> false
-    }
     "switchPadding" -> when {
       v is Switch && arg is Int -> {
         v.setSwitchPadding(arg)
@@ -3268,7 +3261,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "leftStripDrawable" -> when {
       v is TabWidget && arg is Drawable? -> {
-        v.setLeftStripDrawable(arg as Drawable)
+        v.setLeftStripDrawable(arg)
         true
       }
       v is TabWidget && arg is Int -> {
@@ -3279,7 +3272,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "rightStripDrawable" -> when {
       v is TabWidget && arg is Drawable? -> {
-        v.setRightStripDrawable(arg as Drawable)
+        v.setRightStripDrawable(arg)
         true
       }
       v is TabWidget && arg is Int -> {
@@ -3420,7 +3413,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "filters" -> when {
       v is TextView && arg is Array<*> -> {
-        v.setFilters(arg as Array<InputFilter>)
+        v.setFilters(arg as? Array<InputFilter>)
         true
       }
       else -> false
@@ -3556,13 +3549,6 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
       }
       else -> false
     }
-    "minWidth" -> when {
-      v is TextView && arg is Int -> {
-        v.setMinWidth(arg)
-        true
-      }
-      else -> false
-    }
     "movementMethod" -> when {
       v is TextView && arg is MovementMethod -> {
         v.setMovementMethod(arg)
@@ -3688,7 +3674,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "typeface" -> when {
       v is TextView && arg is Typeface? -> {
-        v.setTypeface(arg as Typeface)
+        v.setTypeface(arg)
         true
       }
       else -> false

--- a/anvil/src/sdk17/kotlin/dev/inkremental/dsl/android/widget/SwitchView.kt
+++ b/anvil/src/sdk17/kotlin/dev/inkremental/dsl/android/widget/SwitchView.kt
@@ -19,7 +19,6 @@ import kotlin.Unit
 fun switchView(configure: SwitchViewScope.() -> Unit = {}) =
     v<Switch>(configure.bind(SwitchViewScope))
 abstract class SwitchViewScope : CompoundButtonScope() {
-  fun switchMinWidth(arg: Int): Unit = attr("switchMinWidth", arg)
   fun switchPadding(arg: Int): Unit = attr("switchPadding", arg)
   fun switchTypeface(arg: Typeface): Unit = attr("switchTypeface", arg)
   fun textOff(arg: CharSequence): Unit = attr("textOff", arg)

--- a/anvil/src/sdk17/kotlin/dev/inkremental/dsl/android/widget/TextView.kt
+++ b/anvil/src/sdk17/kotlin/dev/inkremental/dsl/android/widget/TextView.kt
@@ -72,7 +72,6 @@ abstract class TextViewScope : ViewScope() {
   fun minEms(arg: Int): Unit = attr("minEms", arg)
   fun minHeight(arg: Int): Unit = attr("minHeight", arg)
   fun minLines(arg: Int): Unit = attr("minLines", arg)
-  fun minWidth(arg: Int): Unit = attr("minWidth", arg)
   fun movementMethod(arg: MovementMethod): Unit = attr("movementMethod", arg)
   fun onEditorAction(arg: ((
     arg0: TextView,

--- a/anvil/src/sdk19/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
+++ b/anvil/src/sdk19/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
@@ -475,7 +475,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "accessibilityDelegate" -> when {
       arg is View.AccessibilityDelegate? -> {
-        v.setAccessibilityDelegate(arg as View.AccessibilityDelegate)
+        v.setAccessibilityDelegate(arg)
         true
       }
       else -> false
@@ -699,7 +699,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "layerPaint" -> when {
       arg is Paint? -> {
-        v.setLayerPaint(arg as Paint)
+        v.setLayerPaint(arg)
         true
       }
       else -> false
@@ -2025,7 +2025,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "checkMarkDrawable" -> when {
       v is CheckedTextView && arg is Drawable? -> {
-        v.setCheckMarkDrawable(arg as Drawable)
+        v.setCheckMarkDrawable(arg)
         true
       }
       v is CheckedTextView && arg is Int -> {
@@ -2078,7 +2078,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "buttonDrawable" -> when {
       v is CompoundButton && arg is Drawable? -> {
-        v.setButtonDrawable(arg as Drawable)
+        v.setButtonDrawable(arg)
         true
       }
       v is CompoundButton && arg is Int -> {
@@ -2452,7 +2452,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
         true
       }
       v is ImageView && arg is Drawable? -> {
-        v.setImageDrawable(arg as Drawable)
+        v.setImageDrawable(arg)
         true
       }
       else -> false
@@ -2474,7 +2474,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
         true
       }
       v is ImageView && arg is Uri? -> {
-        v.setImageURI(arg as Uri)
+        v.setImageURI(arg)
         true
       }
       else -> false
@@ -2656,7 +2656,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "divider" -> when {
       v is ListView && arg is Drawable? -> {
-        v.setDivider(arg as Drawable)
+        v.setDivider(arg)
         true
       }
       else -> false
@@ -2726,7 +2726,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "displayedValues" -> when {
       v is NumberPicker && arg is Array<*> -> {
-        v.setDisplayedValues(arg as Array<String>)
+        v.setDisplayedValues(arg as? Array<String>)
         true
       }
       else -> false
@@ -2845,7 +2845,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "excludeMimes" -> when {
       v is QuickContactBadge && arg is Array<*> -> {
-        v.setExcludeMimes(arg as Array<String>)
+        v.setExcludeMimes(arg as? Array<String>)
         true
       }
       else -> false
@@ -3035,7 +3035,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "queryHint" -> when {
       v is SearchView && arg is CharSequence? -> {
-        v.setQueryHint(arg as CharSequence)
+        v.setQueryHint(arg)
         true
       }
       else -> false
@@ -3175,13 +3175,6 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
       }
       else -> false
     }
-    "switchMinWidth" -> when {
-      v is Switch && arg is Int -> {
-        v.setSwitchMinWidth(arg)
-        true
-      }
-      else -> false
-    }
     "switchPadding" -> when {
       v is Switch && arg is Int -> {
         v.setSwitchPadding(arg)
@@ -3290,7 +3283,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "leftStripDrawable" -> when {
       v is TabWidget && arg is Drawable? -> {
-        v.setLeftStripDrawable(arg as Drawable)
+        v.setLeftStripDrawable(arg)
         true
       }
       v is TabWidget && arg is Int -> {
@@ -3301,7 +3294,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "rightStripDrawable" -> when {
       v is TabWidget && arg is Drawable? -> {
-        v.setRightStripDrawable(arg as Drawable)
+        v.setRightStripDrawable(arg)
         true
       }
       v is TabWidget && arg is Int -> {
@@ -3442,7 +3435,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "filters" -> when {
       v is TextView && arg is Array<*> -> {
-        v.setFilters(arg as Array<InputFilter>)
+        v.setFilters(arg as? Array<InputFilter>)
         true
       }
       else -> false
@@ -3578,13 +3571,6 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
       }
       else -> false
     }
-    "minWidth" -> when {
-      v is TextView && arg is Int -> {
-        v.setMinWidth(arg)
-        true
-      }
-      else -> false
-    }
     "movementMethod" -> when {
       v is TextView && arg is MovementMethod -> {
         v.setMovementMethod(arg)
@@ -3710,7 +3696,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "typeface" -> when {
       v is TextView && arg is Typeface? -> {
-        v.setTypeface(arg as Typeface)
+        v.setTypeface(arg)
         true
       }
       else -> false

--- a/anvil/src/sdk19/kotlin/dev/inkremental/dsl/android/widget/SwitchView.kt
+++ b/anvil/src/sdk19/kotlin/dev/inkremental/dsl/android/widget/SwitchView.kt
@@ -19,7 +19,6 @@ import kotlin.Unit
 fun switchView(configure: SwitchViewScope.() -> Unit = {}) =
     v<Switch>(configure.bind(SwitchViewScope))
 abstract class SwitchViewScope : CompoundButtonScope() {
-  fun switchMinWidth(arg: Int): Unit = attr("switchMinWidth", arg)
   fun switchPadding(arg: Int): Unit = attr("switchPadding", arg)
   fun switchTypeface(arg: Typeface): Unit = attr("switchTypeface", arg)
   fun textOff(arg: CharSequence): Unit = attr("textOff", arg)

--- a/anvil/src/sdk19/kotlin/dev/inkremental/dsl/android/widget/TextView.kt
+++ b/anvil/src/sdk19/kotlin/dev/inkremental/dsl/android/widget/TextView.kt
@@ -72,7 +72,6 @@ abstract class TextViewScope : ViewScope() {
   fun minEms(arg: Int): Unit = attr("minEms", arg)
   fun minHeight(arg: Int): Unit = attr("minHeight", arg)
   fun minLines(arg: Int): Unit = attr("minLines", arg)
-  fun minWidth(arg: Int): Unit = attr("minWidth", arg)
   fun movementMethod(arg: MovementMethod): Unit = attr("movementMethod", arg)
   fun onEditorAction(arg: ((
     arg0: TextView,

--- a/anvil/src/sdk21/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
+++ b/anvil/src/sdk21/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
@@ -368,7 +368,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "callback" -> when {
       v is TvView && arg is TvView.TvInputCallback? -> {
-        v.setCallback(arg as TvView.TvInputCallback)
+        v.setCallback(arg)
         true
       }
       else -> false
@@ -522,7 +522,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "accessibilityDelegate" -> when {
       arg is View.AccessibilityDelegate? -> {
-        v.setAccessibilityDelegate(arg as View.AccessibilityDelegate)
+        v.setAccessibilityDelegate(arg)
         true
       }
       else -> false
@@ -578,14 +578,14 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "backgroundTintList" -> when {
       arg is ColorStateList? -> {
-        v.setBackgroundTintList(arg as ColorStateList)
+        v.setBackgroundTintList(arg)
         true
       }
       else -> false
     }
     "backgroundTintMode" -> when {
       arg is PorterDuff.Mode? -> {
-        v.setBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setBackgroundTintMode(arg)
         true
       }
       else -> false
@@ -656,13 +656,6 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     "duplicateParentStateEnabled" -> when {
       arg is Boolean -> {
         v.setDuplicateParentStateEnabled(arg)
-        true
-      }
-      else -> false
-    }
-    "elevation" -> when {
-      arg is Float -> {
-        v.setElevation(arg)
         true
       }
       else -> false
@@ -774,7 +767,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "layerPaint" -> when {
       arg is Paint? -> {
-        v.setLayerPaint(arg as Paint)
+        v.setLayerPaint(arg)
         true
       }
       else -> false
@@ -1744,14 +1737,14 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "thumbTintList" -> when {
       v is AbsSeekBar && arg is ColorStateList? -> {
-        v.setThumbTintList(arg as ColorStateList)
+        v.setThumbTintList(arg)
         true
       }
       else -> false
     }
     "thumbTintMode" -> when {
       v is AbsSeekBar && arg is PorterDuff.Mode? -> {
-        v.setThumbTintMode(arg as PorterDuff.Mode)
+        v.setThumbTintMode(arg)
         true
       }
       else -> false
@@ -2248,7 +2241,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "checkMarkDrawable" -> when {
       v is CheckedTextView && arg is Drawable? -> {
-        v.setCheckMarkDrawable(arg as Drawable)
+        v.setCheckMarkDrawable(arg)
         true
       }
       v is CheckedTextView && arg is Int -> {
@@ -2259,14 +2252,14 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "checkMarkTintList" -> when {
       v is CheckedTextView && arg is ColorStateList? -> {
-        v.setCheckMarkTintList(arg as ColorStateList)
+        v.setCheckMarkTintList(arg)
         true
       }
       else -> false
     }
     "checkMarkTintMode" -> when {
       v is CheckedTextView && arg is PorterDuff.Mode? -> {
-        v.setCheckMarkTintMode(arg as PorterDuff.Mode)
+        v.setCheckMarkTintMode(arg)
         true
       }
       else -> false
@@ -2315,7 +2308,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "buttonDrawable" -> when {
       v is CompoundButton && arg is Drawable? -> {
-        v.setButtonDrawable(arg as Drawable)
+        v.setButtonDrawable(arg)
         true
       }
       v is CompoundButton && arg is Int -> {
@@ -2326,14 +2319,14 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "buttonTintList" -> when {
       v is CompoundButton && arg is ColorStateList? -> {
-        v.setButtonTintList(arg as ColorStateList)
+        v.setButtonTintList(arg)
         true
       }
       else -> false
     }
     "buttonTintMode" -> when {
       v is CompoundButton && arg is PorterDuff.Mode? -> {
-        v.setButtonTintMode(arg as PorterDuff.Mode)
+        v.setButtonTintMode(arg)
         true
       }
       else -> false
@@ -2717,7 +2710,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
         true
       }
       v is ImageView && arg is Drawable? -> {
-        v.setImageDrawable(arg as Drawable)
+        v.setImageDrawable(arg)
         true
       }
       else -> false
@@ -2739,7 +2732,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
         true
       }
       v is ImageView && arg is Uri? -> {
-        v.setImageURI(arg as Uri)
+        v.setImageURI(arg)
         true
       }
       else -> false
@@ -2813,14 +2806,14 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "imageTintList" -> when {
       v is ImageView && arg is ColorStateList? -> {
-        v.setImageTintList(arg as ColorStateList)
+        v.setImageTintList(arg)
         true
       }
       else -> false
     }
     "imageTintMode" -> when {
       v is ImageView && arg is PorterDuff.Mode? -> {
-        v.setImageTintMode(arg as PorterDuff.Mode)
+        v.setImageTintMode(arg)
         true
       }
       else -> false
@@ -2935,7 +2928,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "divider" -> when {
       v is ListView && arg is Drawable? -> {
-        v.setDivider(arg as Drawable)
+        v.setDivider(arg)
         true
       }
       else -> false
@@ -3005,7 +2998,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "displayedValues" -> when {
       v is NumberPicker && arg is Array<*> -> {
-        v.setDisplayedValues(arg as Array<String>)
+        v.setDisplayedValues(arg as? Array<String>)
         true
       }
       else -> false
@@ -3096,14 +3089,14 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "indeterminateTintList" -> when {
       v is ProgressBar && arg is ColorStateList? -> {
-        v.setIndeterminateTintList(arg as ColorStateList)
+        v.setIndeterminateTintList(arg)
         true
       }
       else -> false
     }
     "indeterminateTintMode" -> when {
       v is ProgressBar && arg is PorterDuff.Mode? -> {
-        v.setIndeterminateTintMode(arg as PorterDuff.Mode)
+        v.setIndeterminateTintMode(arg)
         true
       }
       else -> false
@@ -3131,14 +3124,14 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "progressBackgroundTintList" -> when {
       v is ProgressBar && arg is ColorStateList? -> {
-        v.setProgressBackgroundTintList(arg as ColorStateList)
+        v.setProgressBackgroundTintList(arg)
         true
       }
       else -> false
     }
     "progressBackgroundTintMode" -> when {
       v is ProgressBar && arg is PorterDuff.Mode? -> {
-        v.setProgressBackgroundTintMode(arg as PorterDuff.Mode)
+        v.setProgressBackgroundTintMode(arg)
         true
       }
       else -> false
@@ -3159,14 +3152,14 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "progressTintList" -> when {
       v is ProgressBar && arg is ColorStateList? -> {
-        v.setProgressTintList(arg as ColorStateList)
+        v.setProgressTintList(arg)
         true
       }
       else -> false
     }
     "progressTintMode" -> when {
       v is ProgressBar && arg is PorterDuff.Mode? -> {
-        v.setProgressTintMode(arg as PorterDuff.Mode)
+        v.setProgressTintMode(arg)
         true
       }
       else -> false
@@ -3180,21 +3173,21 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "secondaryProgressTintList" -> when {
       v is ProgressBar && arg is ColorStateList? -> {
-        v.setSecondaryProgressTintList(arg as ColorStateList)
+        v.setSecondaryProgressTintList(arg)
         true
       }
       else -> false
     }
     "secondaryProgressTintMode" -> when {
       v is ProgressBar && arg is PorterDuff.Mode? -> {
-        v.setSecondaryProgressTintMode(arg as PorterDuff.Mode)
+        v.setSecondaryProgressTintMode(arg)
         true
       }
       else -> false
     }
     "excludeMimes" -> when {
       v is QuickContactBadge && arg is Array<*> -> {
-        v.setExcludeMimes(arg as Array<String>)
+        v.setExcludeMimes(arg as? Array<String>)
         true
       }
       else -> false
@@ -3391,7 +3384,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "queryHint" -> when {
       v is SearchView && arg is CharSequence? -> {
-        v.setQueryHint(arg as CharSequence)
+        v.setQueryHint(arg)
         true
       }
       else -> false
@@ -3538,13 +3531,6 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
       }
       else -> false
     }
-    "switchMinWidth" -> when {
-      v is Switch && arg is Int -> {
-        v.setSwitchMinWidth(arg)
-        true
-      }
-      else -> false
-    }
     "switchPadding" -> when {
       v is Switch && arg is Int -> {
         v.setSwitchPadding(arg)
@@ -3653,7 +3639,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "leftStripDrawable" -> when {
       v is TabWidget && arg is Drawable? -> {
-        v.setLeftStripDrawable(arg as Drawable)
+        v.setLeftStripDrawable(arg)
         true
       }
       v is TabWidget && arg is Int -> {
@@ -3664,7 +3650,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "rightStripDrawable" -> when {
       v is TabWidget && arg is Drawable? -> {
-        v.setRightStripDrawable(arg as Drawable)
+        v.setRightStripDrawable(arg)
         true
       }
       v is TabWidget && arg is Int -> {
@@ -3812,14 +3798,14 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "filters" -> when {
       v is TextView && arg is Array<*> -> {
-        v.setFilters(arg as Array<InputFilter>)
+        v.setFilters(arg as? Array<InputFilter>)
         true
       }
       else -> false
     }
     "fontFeatureSettings" -> when {
       v is TextView && arg is String? -> {
-        v.setFontFeatureSettings(arg as String)
+        v.setFontFeatureSettings(arg)
         true
       }
       else -> false
@@ -3962,13 +3948,6 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
       }
       else -> false
     }
-    "minWidth" -> when {
-      v is TextView && arg is Int -> {
-        v.setMinWidth(arg)
-        true
-      }
-      else -> false
-    }
     "movementMethod" -> when {
       v is TextView && arg is MovementMethod -> {
         v.setMovementMethod(arg)
@@ -4101,7 +4080,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "typeface" -> when {
       v is TextView && arg is Typeface? -> {
-        v.setTypeface(arg as Typeface)
+        v.setTypeface(arg)
         true
       }
       else -> false
@@ -4179,7 +4158,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "navigationContentDescription" -> when {
       v is Toolbar && arg is CharSequence? -> {
-        v.setNavigationContentDescription(arg as CharSequence)
+        v.setNavigationContentDescription(arg)
         true
       }
       v is Toolbar && arg is Int -> {
@@ -4190,7 +4169,7 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
     }
     "navigationIcon" -> when {
       v is Toolbar && arg is Drawable? -> {
-        v.setNavigationIcon(arg as Drawable)
+        v.setNavigationIcon(arg)
         true
       }
       v is Toolbar && arg is Int -> {

--- a/anvil/src/sdk21/kotlin/dev/inkremental/dsl/android/view/View.kt
+++ b/anvil/src/sdk21/kotlin/dev/inkremental/dsl/android/view/View.kt
@@ -57,7 +57,6 @@ abstract class ViewScope : RootViewScope() {
   fun drawingCacheEnabled(arg: Boolean): Unit = attr("drawingCacheEnabled", arg)
   fun drawingCacheQuality(arg: Int): Unit = attr("drawingCacheQuality", arg)
   fun duplicateParentStateEnabled(arg: Boolean): Unit = attr("duplicateParentStateEnabled", arg)
-  fun elevation(arg: Float): Unit = attr("elevation", arg)
   fun enabled(arg: Boolean): Unit = attr("enabled", arg)
   fun fadingEdgeLength(arg: Int): Unit = attr("fadingEdgeLength", arg)
   fun filterTouchesWhenObscured(arg: Boolean): Unit = attr("filterTouchesWhenObscured", arg)

--- a/anvil/src/sdk21/kotlin/dev/inkremental/dsl/android/widget/SwitchView.kt
+++ b/anvil/src/sdk21/kotlin/dev/inkremental/dsl/android/widget/SwitchView.kt
@@ -22,7 +22,6 @@ fun switchView(configure: SwitchViewScope.() -> Unit = {}) =
 abstract class SwitchViewScope : CompoundButtonScope() {
   fun showText(arg: Boolean): Unit = attr("showText", arg)
   fun splitTrack(arg: Boolean): Unit = attr("splitTrack", arg)
-  fun switchMinWidth(arg: Int): Unit = attr("switchMinWidth", arg)
   fun switchPadding(arg: Int): Unit = attr("switchPadding", arg)
   fun switchTypeface(arg: Typeface): Unit = attr("switchTypeface", arg)
   fun textOff(arg: CharSequence): Unit = attr("textOff", arg)

--- a/anvil/src/sdk21/kotlin/dev/inkremental/dsl/android/widget/TextView.kt
+++ b/anvil/src/sdk21/kotlin/dev/inkremental/dsl/android/widget/TextView.kt
@@ -75,7 +75,6 @@ abstract class TextViewScope : ViewScope() {
   fun minEms(arg: Int): Unit = attr("minEms", arg)
   fun minHeight(arg: Int): Unit = attr("minHeight", arg)
   fun minLines(arg: Int): Unit = attr("minLines", arg)
-  fun minWidth(arg: Int): Unit = attr("minWidth", arg)
   fun movementMethod(arg: MovementMethod): Unit = attr("movementMethod", arg)
   fun onEditorAction(arg: ((
     arg0: TextView,

--- a/meta/gradle-plugin/src/main/kotlin/GenerateDslTask.kt
+++ b/meta/gradle-plugin/src/main/kotlin/GenerateDslTask.kt
@@ -242,7 +242,8 @@ abstract class GenerateDslTask : DefaultTask() {
     private fun AttrModel.buildSetter(): CodeBlock {
         val argAsParam = when {
             isVarArg -> "*arg"
-            isNullable || isArray -> "arg as %T"
+            isNullable -> "arg"
+            isArray -> "arg as? %T"
             else -> "arg"
         }
 


### PR DESCRIPTION
This PR changes parameters of some of the dsl's to call with with type size qualifiers (Size class). It add more consistency to API overall, fixing some of the Android's broken Java API.
It also fixes bug with casting nullable values of attributes in setters  to non nullable which leads to crashes.
P.S. If you want to skip looking at changes in generated classes, look into 'add more dsls with typed dimension values' commit