### PR TITLE
Added publishing on external trigger, fixed json publishing

### DIFF
--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      # Latest version can be found here: https://developer.android.com/studio#command-tools
-      ANDROID_SDK_TOOLS: "4333796"
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/push-publish.yml
+++ b/.github/workflows/push-publish.yml
@@ -3,13 +3,12 @@ name: Publish on master push
 on:
   push:
     branches: master
+  repository_dispatch:
+    types: publish
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      # Latest version can be found here: https://developer.android.com/studio#command-tools
-      ANDROID_SDK_TOOLS: "4333796"
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -41,4 +40,5 @@ jobs:
       env:
         BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
         BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+        BINTRAY_REPO: ${{ secrets.BINTRAY_REPO }}
       continue-on-error: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,6 @@ POM_LICENCE_SHORT_NAME=MIT
 POM_LICENCE_NAME=MIT License
 POM_LICENCE_URL=http://www.opensource.org/licenses/mit-license.php
 POM_LICENCE_DIST=repo
+
+# https://github.com/gradle/gradle/issues/11412
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/meta/gradle-plugin/src/main/kotlin/InkrementalGenPlugin.kt
+++ b/meta/gradle-plugin/src/main/kotlin/InkrementalGenPlugin.kt
@@ -65,7 +65,6 @@ const val CONFIGURATION_MODULE = "inkremental"
 const val CONFIGURATION_MODULE_DEF = "inkrementalDef"
 const val USAGE = "inkremental-meta"
 const val FORMAT_AAR = "aar"
-const val FORMAT_JSON = "json"
 
 fun loadPropertiesFromFile(file: File): Properties = Properties().apply {
     try {


### PR DESCRIPTION
Publishing is still flacky for some reason, but major issue was fixed.

We also now can issue HTTP command to re-run publishing in case anything goes wrong As we don't override current version, previous one should be removed beforehand. It goes like this:
```
curl -d '{"event_type": "publish"}' \
    -H "Content-Type: application/json" \
    -H "Authorization: token ${GITHUB_TOKEN}" \
    -H "Accept: application/vnd.github.everest-preview+json"  \
    https://api.github.com/repos/Inkremental/anvil/dispatches
```

Closes #28.