### PR TITLE
Added artifact version to publications

### DIFF
--- a/.github/workflows/push-build.yml
+++ b/.github/workflows/push-build.yml
@@ -8,27 +8,27 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
 
-    - name: Setup JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
 
-    - name: Cache Gradle wrapper dist
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/wrapper/dists
-        key: ${{ runner.os }}-gradle-dists-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Cache Gradle wrapper dist
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper/dists
+          key: ${{ runner.os }}-gradle-dists-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
-    - name: Cache Gradle depdendencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/build.gradle.kts') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
+      - name: Cache Gradle depdendencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/build.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-    - name: Run build
-      run: ./gradlew generateAndCheck
+      - name: Run build
+        run: ./gradlew generateAndCheck

--- a/.github/workflows/push-publish.yml
+++ b/.github/workflows/push-publish.yml
@@ -10,35 +10,35 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
 
-    - name: Setup JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
 
-    - name: Cache Gradle wrapper dist
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/wrapper/dists
-        key: ${{ runner.os }}-gradle-dists-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - name: Cache Gradle wrapper dist
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper/dists
+          key: ${{ runner.os }}-gradle-dists-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
-    - name: Cache Gradle depdendencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/build.gradle.kts') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
+      - name: Cache Gradle depdendencies
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/build.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-    - name: Run build
-      run: ./gradlew check
+      - name: Run build
+        run: ./gradlew check
 
-    - name: Publish artifacts
-      run: ./gradlew generateAndPublish
-      env:
-        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-        BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
-        BINTRAY_REPO: ${{ secrets.BINTRAY_REPO }}
-      continue-on-error: true
+      - name: Publish artifacts
+        run: ./gradlew generateAndPublish
+        env:
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+          BINTRAY_REPO: ${{ secrets.BINTRAY_REPO }}
+        continue-on-error: true

--- a/anvil-appcompat-v7/build.gradle.kts
+++ b/anvil-appcompat-v7/build.gradle.kts
@@ -10,8 +10,10 @@ android {
 	}
 }
 
+val appcompatVersion = "1.1.0"
+
 inkremental {
-	androidLibrary("appcompat-v7") {
+	androidLibrary("appcompat-v7", appcompatVersion) {
 		camelCaseName = "AppCompatv7"
         srcPackage = "androidx.appcompat"
         modulePackage = "dev.inkremental.dsl.androidx.appcompat"
@@ -47,7 +49,7 @@ dependencies {
 	implementation(project(":anvil"))
 	inkremental(project(":anvil", "inkrementalDefSdk17"))
 
-	inkrementalGen("androidx.appcompat:appcompat:1.1.0")
+	inkrementalGen("androidx.appcompat:appcompat:$appcompatVersion")
 
 	testImplementation("junit:junit:$junit_version")
 	testImplementation("org.mockito:mockito-core:$mockito_version")

--- a/anvil-cardview-v7/build.gradle.kts
+++ b/anvil-cardview-v7/build.gradle.kts
@@ -10,8 +10,10 @@ android {
 	}
 }
 
+val cardVersion = "1.0.0"
+
 inkremental {
-	androidLibrary("cardview-v7") {
+	androidLibrary("cardview-v7", cardVersion) {
 		camelCaseName = "CardViewv7"
         srcPackage = "androidx.cardview"
         modulePackage = "dev.inkremental.dsl.androidx.cardview"
@@ -33,7 +35,7 @@ dependencies {
 	implementation(project(":anvil"))
 	inkremental(project(":anvil", "inkrementalDefSdk17"))
 
-	inkrementalGen("androidx.cardview:cardview:1.0.0")
+	inkrementalGen("androidx.cardview:cardview:$cardVersion")
 
 	testImplementation("junit:junit:$junit_version")
 	testImplementation("org.mockito:mockito-core:$mockito_version")

--- a/anvil-constraintlayout/build.gradle.kts
+++ b/anvil-constraintlayout/build.gradle.kts
@@ -10,8 +10,10 @@ android {
     }
 }
 
+val constraintVersion = "1.1.3"
+
 inkremental {
-    androidLibrary("constraintlayout") {
+    androidLibrary("constraintlayout", constraintVersion) {
         camelCaseName = "Constraint"
         srcPackage = "androidx.constraintlayout"
         modulePackage = "dev.inkremental.dsl.androidx.constraintlayout"
@@ -25,9 +27,9 @@ dependencies {
 	implementation(project(":anvil"))
 	inkremental(project(":anvil", "inkrementalDefSdk17"))
 
-    //inkrementalGen("androidx.constraintlayout:constraintlayout:1.1.3")
-    api("androidx.constraintlayout:constraintlayout:1.1.3")
-    api("androidx.constraintlayout:constraintlayout-solver:1.1.3")
+    //inkrementalGen("androidx.constraintlayout:constraintlayout:$constraintVersion")
+    api("androidx.constraintlayout:constraintlayout:$constraintVersion")
+    api("androidx.constraintlayout:constraintlayout-solver:$constraintVersion")
 
     testImplementation("junit:junit:$junit_version")
     testImplementation("org.mockito:mockito-core:$mockito_version")

--- a/anvil-design/build.gradle.kts
+++ b/anvil-design/build.gradle.kts
@@ -10,8 +10,10 @@ android {
 	}
 }
 
+val materialVersion = "1.0.0"
+
 inkremental {
-	androidLibrary("material") {
+	androidLibrary("material", materialVersion) {
 		camelCaseName = "Material"
         srcPackage = "com.google.android.material"
         modulePackage = "dev.inkremental.dsl.google.android.material"
@@ -85,7 +87,7 @@ dependencies {
 	implementation(project(":anvil-recyclerview-v7"))
 	inkremental(project(":anvil-recyclerview-v7", "inkrementalDefRecyclerViewv7"))
 
-	inkrementalGen("com.google.android.material:material:1.0.0")
+	inkrementalGen("com.google.android.material:material:$materialVersion")
 
 	testImplementation("junit:junit:$junit_version")
 	testImplementation("org.mockito:mockito-core:$mockito_version")

--- a/anvil-gridlayout-v7/build.gradle.kts
+++ b/anvil-gridlayout-v7/build.gradle.kts
@@ -10,8 +10,10 @@ android {
 	}
 }
 
+val gridVersion = "1.0.0"
+
 inkremental {
-	androidLibrary("gridlayout-v7") {
+	androidLibrary("gridlayout-v7", gridVersion) {
 		camelCaseName = "GridLayoutv7"
         srcPackage = "androidx.gridlayout"
         modulePackage = "dev.inkremental.dsl.androidx.gridlayout"
@@ -25,7 +27,7 @@ dependencies {
 	implementation(project(":anvil"))
 	inkremental(project(":anvil", "inkrementalDefSdk17"))
 
-	inkrementalGen("androidx.gridlayout:gridlayout:1.0.0")
+	inkrementalGen("androidx.gridlayout:gridlayout:$gridVersion")
 
 	testImplementation("junit:junit:$junit_version")
 	testImplementation("org.mockito:mockito-core:$mockito_version")

--- a/anvil-recyclerview-v7/build.gradle.kts
+++ b/anvil-recyclerview-v7/build.gradle.kts
@@ -10,8 +10,10 @@ android {
 	}
 }
 
+val recyclerVersion = "1.1.0"
+
 inkremental {
-	androidLibrary("recyclerview-v7") {
+	androidLibrary("recyclerview-v7", recyclerVersion) {
 		camelCaseName = "RecyclerViewv7"
         srcPackage = "androidx.recyclerview"
         modulePackage = "dev.inkremental.dsl.androidx.recyclerview"
@@ -30,7 +32,7 @@ dependencies {
 	implementation(project(":anvil"))
 	inkremental(project(":anvil", "inkrementalDefSdk17"))
 
-	inkrementalGen("androidx.recyclerview:recyclerview:1.1.0")
+	inkrementalGen("androidx.recyclerview:recyclerview:$recyclerVersion")
 
 	testImplementation("junit:junit:$junit_version")
 	testImplementation("org.mockito:mockito-core:$mockito_version")

--- a/anvil-support-v4/build.gradle.kts
+++ b/anvil-support-v4/build.gradle.kts
@@ -10,8 +10,10 @@ android {
 	}
 }
 
+val coreVersion = "1.1.0"
+
 inkremental {
-	androidLibrary("support-core-ui") {
+	androidLibrary("support-core-ui", coreVersion) {
 		camelCaseName = "SupportCoreUi"
         srcPackage = "androidx.core"
         modulePackage = "dev.inkremental.dsl.androidx.core"
@@ -35,7 +37,7 @@ dependencies {
 	inkremental(project(":anvil", "inkrementalDefSdk17"))
 
 	inkrementalGen("androidx.coordinatorlayout:coordinatorlayout:1.0.0")
-	inkrementalGen("androidx.core:core:1.1.0")
+	inkrementalGen("androidx.core:core:$coreVersion")
 	inkrementalGen("androidx.drawerlayout:drawerlayout:1.0.0")
 	inkrementalGen("androidx.legacy:legacy-support-core-ui:1.0.0")
 	inkrementalGen("androidx.slidingpanelayout:slidingpanelayout:1.0.0")

--- a/anvil-yogalayout/build.gradle.kts
+++ b/anvil-yogalayout/build.gradle.kts
@@ -10,8 +10,10 @@ android {
     }
 }
 
+val yogaVersion = "1.16.0"
+
 inkremental {
-    androidLibrary("yogalayout") {
+    androidLibrary("yogalayout", yogaVersion) {
         camelCaseName = "Yoga"
         srcPackage = "com.facebook.yoga"
         modulePackage = "dev.inkremental.dsl.yoga"
@@ -25,7 +27,7 @@ dependencies {
 	implementation(project(":anvil"))
 	inkremental(project(":anvil", "inkrementalDefSdk17"))
 
-    api("com.facebook.yoga.android:yoga-layout:1.16.0")
+    api("com.facebook.yoga.android:yoga-layout:$yogaVersion")
     api("com.facebook.soloader:soloader:0.6.1")
     api("androidx.constraintlayout:constraintlayout-solver:1.1.3")
 

--- a/meta/gradle-plugin/src/main/kotlin/InkrementalMetaExtension.kt
+++ b/meta/gradle-plugin/src/main/kotlin/InkrementalMetaExtension.kt
@@ -19,10 +19,12 @@ open class InkrementalMetaExtension @Inject constructor(objectFactory: ObjectFac
 
     fun androidLibrary(
         name: String,
+        version: String,
         action: InkrementalMetaModule.() -> Unit) =
         modules.register(name) {
             type = InkrementalType.LIBRARY
             platform = InkrementalPlatform.ANDROID
+            this.version = version
             action()
         }
 
@@ -38,6 +40,7 @@ open class InkrementalMetaExtension @Inject constructor(objectFactory: ObjectFac
 
 data class InkrementalMetaModule(
     var name: String = "",
+    var version: String = "",
     var type: InkrementalType = InkrementalType.LIBRARY,
     var platform: InkrementalPlatform? = null,
     var camelCaseName: String = "",

--- a/meta/gradle-plugin/src/main/kotlin/InkrementalModulePlugin.kt
+++ b/meta/gradle-plugin/src/main/kotlin/InkrementalModulePlugin.kt
@@ -99,10 +99,11 @@ class InkrementalModulePlugin : Plugin<Project> {
             }
         }
 
-        fun registerAnvilPublication(name: String, bundleName: String, artifactId: String) =
+        fun registerPublication(name: String, bundleName: String, artifactId: String, verion: String) =
             registerAnvilPublication(
                 name,
                 artifactId,
+                verion,
                 tasks.getByName("bundle${bundleName}ReleaseAar"),
                 sourcesJar,
                 javadocJar,
@@ -111,14 +112,15 @@ class InkrementalModulePlugin : Plugin<Project> {
 
         afterEvaluate {
             extensions.getByType<InkrementalMetaExtension>().modules.forEach {
+                val version = project.version.toString() + if(it.version.isNotEmpty()) "-${it.version}" else ""
                 when(it.type) {
                     InkrementalType.SDK -> {
-                        registerAnvilPublication("Sdk17", "Sdk17", prop("POM_ARTIFACT_SDK17_ID")!!)
-                        registerAnvilPublication("Sdk19", "Sdk19", prop("POM_ARTIFACT_SDK19_ID")!!)
-                        registerAnvilPublication("Sdk21", "Sdk21", prop("POM_ARTIFACT_SDK21_ID")!!)
+                        registerPublication("Sdk17", "Sdk17", prop("POM_ARTIFACT_SDK17_ID")!!, version)
+                        registerPublication("Sdk19", "Sdk19", prop("POM_ARTIFACT_SDK19_ID")!!, version)
+                        registerPublication("Sdk21", "Sdk21", prop("POM_ARTIFACT_SDK21_ID")!!, version)
                     }
                     InkrementalType.LIBRARY ->
-                        registerAnvilPublication(it.camelCaseName, "", prop("POM_ARTIFACT_ID")!!)
+                        registerPublication(it.camelCaseName, "", prop("POM_ARTIFACT_ID")!!, version)
                 }
             }
         }
@@ -127,13 +129,14 @@ class InkrementalModulePlugin : Plugin<Project> {
     private fun Project.registerAnvilPublication(
         name: String,
         artifactId: String,
+        version: String,
         vararg artifacts: Any) =
         project.extensions.getByType<PublishingExtension>()
             .publications
             .register<MavenPublication>(name) {
                 this.groupId = project.group.toString()
                 this.artifactId = artifactId
-                this.version = project.version.toString()
+                this.version = version
                 artifacts.forEach { artifact(it) }
                 fixPom(this)
             }


### PR DESCRIPTION
With this PR the project still has one library version with corresponding publication per Gradle project, but artifact version is altered to contain both project version and one for processed artifact. So for Inkremental 0.9 and Material library 1.0.0 we have the following artifact: `dev.inkremental:anvil-design:0.9-1.0.0`

Closes #41.