### PR TITLE
Fixed Bintray publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("org.jetbrains.kotlin.multiplatform") version "1.3.60" apply false
-    id("org.jetbrains.kotlin.android") version "1.3.60" apply false
+    id("org.jetbrains.kotlin.multiplatform") version "1.3.61" apply false
+    id("org.jetbrains.kotlin.android") version "1.3.61" apply false
     id("com.android.application") version "3.5.2" apply false
     id("com.android.library") version "3.5.2" apply false
     id("dev.inkremental.module") version "0.7.1" apply false
@@ -40,39 +40,19 @@ subprojects {
 }
 
 // TODO constraintlayout and yogalayout
-
-tasks.register("generateAndCheck") {
-    dependsOn(
-        ":anvil:check",
-        ":anvil-appcompat-v7:check",
-        ":anvil-gridlayout-v7:check",
-        ":anvil-recyclerview-v7:check",
-        ":anvil-cardview-v7:check",
-        ":anvil-design:check",
-        ":anvil-support-v4:check"
-    )
+val mainSubprojects = listOf(
+    "anvil",
+    "anvil-appcompat-v7",
+    "anvil-gridlayout-v7",
+    "anvil-recyclerview-v7",
+    "anvil-cardview-v7",
+    "anvil-design",
+    "anvil-support-v4"
+)
+fun registerGlobalTask(name: String, subprojectTask: String) = tasks.register<Task>(name) {
+    setDependsOn(mainSubprojects.map { ":$it:$subprojectTask" })
 }
 
-tasks.register("generateAndPublishLocally") {
-    dependsOn(
-        ":anvil:publishToMavenLocal",
-        ":anvil-appcompat-v7:publishToMavenLocal",
-        ":anvil-gridlayout-v7:publishToMavenLocal",
-        ":anvil-recyclerview-v7:publishToMavenLocal",
-        ":anvil-cardview-v7:publishToMavenLocal",
-        ":anvil-design:publishToMavenLocal",
-        ":anvil-support-v4:publishToMavenLocal"
-    )
-}
-
-tasks.register("generateAndPublish") {
-    dependsOn(
-        ":anvil:publish",
-        ":anvil-appcompat-v7:publish",
-        ":anvil-gridlayout-v7:publish",
-        ":anvil-recyclerview-v7:publish",
-        ":anvil-cardview-v7:publish",
-        ":anvil-design:publish",
-        ":anvil-support-v4:publish"
-    )
-}
+registerGlobalTask("generateAndCheck", "check")
+registerGlobalTask("generateAndPublishLocally", "publishToMavenLocal")
+registerGlobalTask("generateAndPublish", "publishAllPublicationsToBintrayRepository")

--- a/meta/build.gradle.kts
+++ b/meta/build.gradle.kts
@@ -1,8 +1,8 @@
 import java.util.*
 
 plugins {
-    kotlin("jvm") version "1.3.60" apply false
-    kotlin("plugin.serialization") version "1.3.60" apply false
+    kotlin("jvm") version "1.3.61" apply false
+    kotlin("plugin.serialization") version "1.3.61" apply false
 }
 
 fun loadProperties(fileName: String) =

--- a/meta/gradle-plugin/build.gradle.kts
+++ b/meta/gradle-plugin/build.gradle.kts
@@ -16,8 +16,8 @@ dependencies {
         exclude("org.jetbrains.kotlin", "kotlin-native-library-reader")
     }
 
-    //compileClasspath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.60")
-    //runtimeClasspath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.60")
+    //compileClasspath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
+    //runtimeClasspath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
     compileClasspath("com.android.tools.build:gradle:3.5.3")
     runtimeClasspath("com.android.tools.build:gradle:3.5.3")
 }

--- a/meta/introspect-ios/src/main/kotlin/main.kt
+++ b/meta/introspect-ios/src/main/kotlin/main.kt
@@ -21,7 +21,7 @@ import org.jetbrains.kotlin.konan.file.File as KFile
 fun main() {
     // org.jetbrais.kotlin.gradle.utils.NativeCompilerDownloader
     val distRoot = File(System.getenv("HOME")!!)
-        .resolve(".konan/kotlin-native-macos-1.3.60")
+        .resolve(".konan/kotlin-native-macos-1.3.61")
 
     val distribution = buildDistribution(distRoot.absolutePath)
     println("Home: ${distribution.konanHome}")


### PR DESCRIPTION
* Fixed wrong repo URL and duplicate artifacts between publications
* Removed inadequate sources and javadoc jars (TODO: implement proper ones, covered by #42)
* Switched Kotlin 1.3.60 -> 1.3.61

For some reason I still occasionally get 405 on different publications randomly, but I'm hoping it's caused by some temporary issues with Bintray. Will see.

I've also decided to postpone two-repo setup I've mentioned in chat, so that we finally can get proper publications ASAP.