### PR TITLE
Move tags values to the Mount class and clear them explicitly on unmount

### DIFF
--- a/anvil/src/main/kotlin/dev/inkremental/Inkremental.kt
+++ b/anvil/src/main/kotlin/dev/inkremental/Inkremental.kt
@@ -186,17 +186,12 @@ object Inkremental {
         private val tags: MutableMap<View, MutableMap<String, Any?>> = WeakHashMap()
 
         operator fun set(v: View, key: String, value: Any?) {
-            var attrs = tags[v]
-            if (attrs == null) {
-                attrs = HashMap()
-                tags[v] = attrs
-            }
+            val attrs = tags.getOrPut(v) { HashMap() }
             attrs[key] = value
         }
 
         operator fun get(v: View?, key: String): Any? {
-            val attrs = tags[v] ?: return null
-            return attrs[key]
+            return tags[v]?.get(key)
         }
 
         fun cleanTags() {

--- a/anvil/src/main/kotlin/dev/inkremental/Inkremental.kt
+++ b/anvil/src/main/kotlin/dev/inkremental/Inkremental.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/anvil/src/main/kotlin/dev/inkremental/dsl/android/CustomSdkSetter.kt
+++ b/anvil/src/main/kotlin/dev/inkremental/dsl/android/CustomSdkSetter.kt
@@ -43,11 +43,13 @@ const val CLIP_HORIZONTAL = Gravity.CLIP_HORIZONTAL
 const val START = Gravity.START
 const val END = Gravity.END
 
+const val INIT_LITERAL = "init"
+
 inline class Sp(val value: Float)
 inline class Dip(val value: Int)
 inline class Px(val value: Int)
 
-fun ViewScope.init(action: (View) -> Unit) = attr("init", action)
+fun ViewScope.init(action: (View) -> Unit) = attr(INIT_LITERAL, action)
 fun ViewScope.size(w: Size, h: Size) = attr("size", w to h)
 fun ViewScope.tag(key: Int, value: Any?) = attr("tag", key to value)
 
@@ -124,12 +126,9 @@ fun SwitchViewScope.switchMinWidth(arg: Dip): Unit = attr("switchMinWidth", arg.
 
 object CustomSdkSetter : Inkremental.AttributeSetter<Any> {
     override fun set(v: View, name: String, value: Any?, prevValue: Any?): Boolean = when (name) {
-        "init" -> when {
-            value is Function<*> -> {
-                if (Inkremental.get(v, "_initialized") == null) {
-                    Inkremental.set(v, "_initialized", true)
-                    (value as (View) -> Any?)(v)
-                }
+        INIT_LITERAL -> when (value) {
+            is Function<*> -> {
+                (value as (View) -> Any?)(v)
                 true
             }
             else -> false

--- a/anvil/src/test/kotlin/dev/inkremental/MountTest.kt
+++ b/anvil/src/test/kotlin/dev/inkremental/MountTest.kt
@@ -35,10 +35,13 @@ class MountTest : Utils() {
     fun testMountReplacesViews() {
         Inkremental.mount(container, testLayout)
         assertEquals(1, container.childCount)
+        Inkremental.unmount(container)
         Inkremental.mount(container, empty)
         assertEquals(0, container.childCount)
+        Inkremental.unmount(container)
         Inkremental.mount(container, testLayout)
         assertEquals(1, container.childCount)
+        Inkremental.unmount(container)
     }
 
     @Test


### PR DESCRIPTION
Move tags values from the global static scope to the mount class and clear them explicitly on unmount. 
This is important for preventing memory leaks because before that all cached values of properties are kept globally and cleaning them was relied on WeakHashMap, which is not very reliable mechanism. 

This PR also prevents holding the "init" closure in tags.