### PR TITLE
Add more transformers and fix some APIs

### DIFF
--- a/anvil/build.gradle.kts
+++ b/anvil/build.gradle.kts
@@ -1,3 +1,5 @@
+import dev.inkremental.meta.model.DslTransformer.*
+
 plugins {
 	id("com.android.library")
 	id("org.jetbrains.kotlin.android")
@@ -66,6 +68,13 @@ inkremental {
 			"android.webkit.WebView" to mapOf(
 				"setWebContentsDebuggingEnabled" to false
 			)
+		)
+		transformers = mapOf(
+				"android.view.View" to mapOf(
+						"setMinimumHeight" to listOf(IntToDpTransformer),
+						"setMinimumWidth" to listOf(IntToDpTransformer),
+						"setBackground" to listOf(NullableForSureTransformer)
+				)
 		)
 	}
 }

--- a/anvil/src/gen-sdk-17/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
+++ b/anvil/src/gen-sdk-17/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
@@ -109,6 +109,7 @@ import android.widget.ViewSwitcher
 import android.widget.ZoomButton
 import android.widget.ZoomControls
 import dev.inkremental.Inkremental
+import dev.inkremental.dip
 import java.util.Locale
 import kotlin.Any
 import kotlin.Array
@@ -718,15 +719,15 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
       else -> false
     }
     "minimumHeight" -> when {
-      arg is Int -> {
-        v.setMinimumHeight(arg)
+       arg is Int -> {
+        v.setMinimumHeight(dip(arg))
         true
       }
       else -> false
     }
     "minimumWidth" -> when {
-      arg is Int -> {
-        v.setMinimumWidth(arg)
+       arg is Int -> {
+        v.setMinimumWidth(dip(arg))
         true
       }
       else -> false

--- a/anvil/src/gen-sdk-17/kotlin/dev/inkremental/dsl/android/view/View.kt
+++ b/anvil/src/gen-sdk-17/kotlin/dev/inkremental/dsl/android/view/View.kt
@@ -17,6 +17,7 @@ import dev.inkremental.RootViewScope
 import dev.inkremental.attr
 import dev.inkremental.bind
 import dev.inkremental.dsl.android.CustomSdkSetter
+import dev.inkremental.dsl.android.Dip
 import dev.inkremental.dsl.android.SdkSetter
 import dev.inkremental.v
 import kotlin.Any
@@ -34,7 +35,7 @@ abstract class ViewScope : RootViewScope() {
   fun activated(arg: Boolean): Unit = attr("activated", arg)
   fun alpha(arg: Float): Unit = attr("alpha", arg)
   fun animation(arg: Animation): Unit = attr("animation", arg)
-  fun background(arg: Drawable): Unit = attr("background", arg)
+  fun background(arg: Drawable?): Unit = attr("background", arg)
   fun backgroundColor(arg: Int): Unit = attr("backgroundColor", arg)
   fun backgroundResource(arg: Int): Unit = attr("backgroundResource", arg)
   fun bottom(arg: Int): Unit = attr("bottom", arg)
@@ -65,8 +66,8 @@ abstract class ViewScope : RootViewScope() {
   fun layoutParams(arg: ViewGroup.LayoutParams): Unit = attr("layoutParams", arg)
   fun left(arg: Int): Unit = attr("left", arg)
   fun longClickable(arg: Boolean): Unit = attr("longClickable", arg)
-  fun minimumHeight(arg: Int): Unit = attr("minimumHeight", arg)
-  fun minimumWidth(arg: Int): Unit = attr("minimumWidth", arg)
+  fun minimumHeight(arg: Dip): Unit = attr("minimumHeight", arg.value)
+  fun minimumWidth(arg: Dip): Unit = attr("minimumWidth", arg.value)
   fun nextFocusDownId(arg: Int): Unit = attr("nextFocusDownId", arg)
   fun nextFocusForwardId(arg: Int): Unit = attr("nextFocusForwardId", arg)
   fun nextFocusLeftId(arg: Int): Unit = attr("nextFocusLeftId", arg)

--- a/anvil/src/gen-sdk-19/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
+++ b/anvil/src/gen-sdk-19/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
@@ -110,6 +110,7 @@ import android.widget.ViewSwitcher
 import android.widget.ZoomButton
 import android.widget.ZoomControls
 import dev.inkremental.Inkremental
+import dev.inkremental.dip
 import java.util.Locale
 import kotlin.Any
 import kotlin.Array
@@ -733,15 +734,15 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
       else -> false
     }
     "minimumHeight" -> when {
-      arg is Int -> {
-        v.setMinimumHeight(arg)
+       arg is Int -> {
+        v.setMinimumHeight(dip(arg))
         true
       }
       else -> false
     }
     "minimumWidth" -> when {
-      arg is Int -> {
-        v.setMinimumWidth(arg)
+       arg is Int -> {
+        v.setMinimumWidth(dip(arg))
         true
       }
       else -> false

--- a/anvil/src/gen-sdk-19/kotlin/dev/inkremental/dsl/android/view/View.kt
+++ b/anvil/src/gen-sdk-19/kotlin/dev/inkremental/dsl/android/view/View.kt
@@ -18,6 +18,7 @@ import dev.inkremental.RootViewScope
 import dev.inkremental.attr
 import dev.inkremental.bind
 import dev.inkremental.dsl.android.CustomSdkSetter
+import dev.inkremental.dsl.android.Dip
 import dev.inkremental.dsl.android.SdkSetter
 import dev.inkremental.v
 import kotlin.Any
@@ -36,7 +37,7 @@ abstract class ViewScope : RootViewScope() {
   fun activated(arg: Boolean): Unit = attr("activated", arg)
   fun alpha(arg: Float): Unit = attr("alpha", arg)
   fun animation(arg: Animation): Unit = attr("animation", arg)
-  fun background(arg: Drawable): Unit = attr("background", arg)
+  fun background(arg: Drawable?): Unit = attr("background", arg)
   fun backgroundColor(arg: Int): Unit = attr("backgroundColor", arg)
   fun backgroundResource(arg: Int): Unit = attr("backgroundResource", arg)
   fun bottom(arg: Int): Unit = attr("bottom", arg)
@@ -68,8 +69,8 @@ abstract class ViewScope : RootViewScope() {
   fun layoutParams(arg: ViewGroup.LayoutParams): Unit = attr("layoutParams", arg)
   fun left(arg: Int): Unit = attr("left", arg)
   fun longClickable(arg: Boolean): Unit = attr("longClickable", arg)
-  fun minimumHeight(arg: Int): Unit = attr("minimumHeight", arg)
-  fun minimumWidth(arg: Int): Unit = attr("minimumWidth", arg)
+  fun minimumHeight(arg: Dip): Unit = attr("minimumHeight", arg.value)
+  fun minimumWidth(arg: Dip): Unit = attr("minimumWidth", arg.value)
   fun nextFocusDownId(arg: Int): Unit = attr("nextFocusDownId", arg)
   fun nextFocusForwardId(arg: Int): Unit = attr("nextFocusForwardId", arg)
   fun nextFocusLeftId(arg: Int): Unit = attr("nextFocusLeftId", arg)

--- a/anvil/src/gen-sdk-21/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
+++ b/anvil/src/gen-sdk-21/kotlin/dev/inkremental/dsl/android/SdkSetter.kt
@@ -119,6 +119,7 @@ import android.widget.ViewSwitcher
 import android.widget.ZoomButton
 import android.widget.ZoomControls
 import dev.inkremental.Inkremental
+import dev.inkremental.dip
 import java.util.Locale
 import kotlin.Any
 import kotlin.Array
@@ -801,15 +802,15 @@ object SdkSetter : Inkremental.AttributeSetter<Any> {
       else -> false
     }
     "minimumHeight" -> when {
-      arg is Int -> {
-        v.setMinimumHeight(arg)
+       arg is Int -> {
+        v.setMinimumHeight(dip(arg))
         true
       }
       else -> false
     }
     "minimumWidth" -> when {
-      arg is Int -> {
-        v.setMinimumWidth(arg)
+       arg is Int -> {
+        v.setMinimumWidth(dip(arg))
         true
       }
       else -> false

--- a/anvil/src/gen-sdk-21/kotlin/dev/inkremental/dsl/android/view/View.kt
+++ b/anvil/src/gen-sdk-21/kotlin/dev/inkremental/dsl/android/view/View.kt
@@ -23,6 +23,7 @@ import dev.inkremental.RootViewScope
 import dev.inkremental.attr
 import dev.inkremental.bind
 import dev.inkremental.dsl.android.CustomSdkSetter
+import dev.inkremental.dsl.android.Dip
 import dev.inkremental.dsl.android.SdkSetter
 import dev.inkremental.v
 import kotlin.Any
@@ -42,7 +43,7 @@ abstract class ViewScope : RootViewScope() {
   fun activated(arg: Boolean): Unit = attr("activated", arg)
   fun alpha(arg: Float): Unit = attr("alpha", arg)
   fun animation(arg: Animation): Unit = attr("animation", arg)
-  fun background(arg: Drawable): Unit = attr("background", arg)
+  fun background(arg: Drawable?): Unit = attr("background", arg)
   fun backgroundColor(arg: Int): Unit = attr("backgroundColor", arg)
   fun backgroundResource(arg: Int): Unit = attr("backgroundResource", arg)
   fun backgroundTintList(arg: ColorStateList?): Unit = attr("backgroundTintList", arg)
@@ -77,8 +78,8 @@ abstract class ViewScope : RootViewScope() {
   fun layoutParams(arg: ViewGroup.LayoutParams): Unit = attr("layoutParams", arg)
   fun left(arg: Int): Unit = attr("left", arg)
   fun longClickable(arg: Boolean): Unit = attr("longClickable", arg)
-  fun minimumHeight(arg: Int): Unit = attr("minimumHeight", arg)
-  fun minimumWidth(arg: Int): Unit = attr("minimumWidth", arg)
+  fun minimumHeight(arg: Dip): Unit = attr("minimumHeight", arg.value)
+  fun minimumWidth(arg: Dip): Unit = attr("minimumWidth", arg.value)
   fun nestedScrollingEnabled(arg: Boolean): Unit = attr("nestedScrollingEnabled", arg)
   fun nextFocusDownId(arg: Int): Unit = attr("nextFocusDownId", arg)
   fun nextFocusForwardId(arg: Int): Unit = attr("nextFocusForwardId", arg)

--- a/meta/gradle-plugin/src/main/kotlin/GenerateDslTask.kt
+++ b/meta/gradle-plugin/src/main/kotlin/GenerateDslTask.kt
@@ -266,8 +266,11 @@ abstract class GenerateDslTask : DefaultTask() {
         // TODO check if getter is present and if so, use property assignment, else use setter call
         return buildCodeBlock {
             if (owner.isRoot) {
-                beginControlFlow("arg is %T ->", type.starProjectedType.copy(nullable = isNullable))
-                addStatement("v.$setterName($argAsParam)", type.parametrizedType)
+                val v = owner.parametrizedType?.let { "(v as $it)" } ?: "v"
+                if (!handleTransformersForAttrSetter(transformers, this, owner, v, setterName, argAsParam)) {
+                    beginControlFlow("arg is %T ->", type.starProjectedType.copy(nullable = isNullable))
+                    addStatement("v.$setterName($argAsParam)", type.parametrizedType)
+                }
                 addStatement("true")
                 endControlFlow()
             } else {


### PR DESCRIPTION
This PR: 
- fixes the bug of not applying trasformers to dsl part for SDK generator
- Adds transformer for forcing nullability for dsl method
- Adds transformer for converting api that require pixels to make them require DP
- Converts minWidth/minHeight to require to DP
- Allow accepting nullable value for setting background despite of lack nullability annotations in Android SDK.