### PR TITLE
Used patched version of Jekyll action which supports non-root Gemfile

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -18,8 +18,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
 
-    - uses: helaili/jekyll-action@eb6eabe # v2.0.2
+    #- uses: helaili/jekyll-action@eb6eabe # v2.0.2
+    - uses: r4zzz4k/jekyll-action@263712c
       env:
         JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
       with:
-        jekyll_src: docs
+        jekyll_root: docs
+

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,4 +21,4 @@ aux_links:
 
 footer_content: "Copyright &copy; 2020 Inkremental contributors. Distributed by an <a href=\"https://github.com/inkremental/inkremental/tree/master/LICENSE\">Apache 2.0 license.</a>"
 
-edit_baseurl: "https://github.com/inkremental/inkremental/edit/master"
+edit_baseurl: "https://github.com/inkremental/inkremental/edit/master/docs"


### PR DESCRIPTION
Applied patch can be found here: r4zzz4k/jekyll-action@263712c.