### PR TITLE
Support xml files

### DIFF
--- a/anvil/src/main/kotlin/dev/inkremental/KAnvil.kt
+++ b/anvil/src/main/kotlin/dev/inkremental/KAnvil.kt
@@ -25,11 +25,18 @@ inline fun <reified T: View> v(noinline r: () -> Unit = {}) = v(T::class, r)
 
 inline fun <reified T: View, reified S: ViewScope> v(s: S, noinline r: S.() -> Unit = {}) = v(T::class, r.bind(s))
 
+inline fun <reified S: ViewScope>xml(@LayoutRes layoutId: Int, s: S, noinline r: S.() -> Unit = {}) {
+    start(layoutId)
+    r.bind(s).invoke()
+    end()
+}
+
 fun xml(@LayoutRes layoutId: Int, r: () -> Unit = {}) {
-    Inkremental.currentMount()?.iterator?.start(null, layoutId)
+    start(layoutId)
     r()
     end()
 }
+fun start(@LayoutRes layoutId: Int) = Inkremental.currentMount()?.iterator?.start(null, layoutId)
 fun end() = Inkremental.currentMount()?.iterator?.end()
 fun skip() = Inkremental.currentMount()?.iterator?.skip()
 

--- a/anvil/src/main/kotlin/dev/inkremental/KAnvil.kt
+++ b/anvil/src/main/kotlin/dev/inkremental/KAnvil.kt
@@ -25,12 +25,7 @@ inline fun <reified T: View> v(noinline r: () -> Unit = {}) = v(T::class, r)
 
 inline fun <reified T: View, reified S: ViewScope> v(s: S, noinline r: S.() -> Unit = {}) = v(T::class, r.bind(s))
 
-inline fun <reified S: ViewScope>xml(@LayoutRes layoutId: Int, s: S, noinline r: S.() -> Unit = {}) {
-    start(layoutId)
-    r.bind(s).invoke()
-    end()
-}
-
+inline fun <reified S: ViewScope> xml(@LayoutRes layoutId: Int, s: S, noinline r: S.() -> Unit = {}) = xml(layoutId, r.bind(s))
 fun xml(@LayoutRes layoutId: Int, r: () -> Unit = {}) {
     start(layoutId)
     r()


### PR DESCRIPTION
Add support for xml files to be able to specify the scope inside inside it.
instead of writting:
xml(R.layout.view_camera) { ... }
we can now write:
xml(R.layout.view_camera, FrameLayoutScope) { -- FrameLayoutScope here -- }
Sure, we must "match" the layout inside the xml file and the one in the code.  But its help a lot.