### PR TITLE
Update Kotlin to 1.4 and bump version

### DIFF
--- a/.github/workflows/push-publish.yml
+++ b/.github/workflows/push-publish.yml
@@ -33,5 +33,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Install SDK
+        run: |
+          echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "platforms;android-17" --sdk_root=${ANDROID_SDK_ROOT}
+          echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "platforms;android-19" --sdk_root=${ANDROID_SDK_ROOT}
+          echo "y" | sudo /usr/local/lib/android/sdk/tools/bin/sdkmanager --install "platforms;android-21" --sdk_root=${ANDROID_SDK_ROOT}
+
       - name: Run build
         run: ./gradlew check

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("org.jetbrains.kotlin.multiplatform") version "1.3.61" apply false
-    id("org.jetbrains.kotlin.android") version "1.3.61" apply false
+    id("org.jetbrains.kotlin.multiplatform") version "1.4.32" apply false
+    id("org.jetbrains.kotlin.android") version "1.4.32" apply false
     id("com.android.application") version "3.5.2" apply false
     id("com.android.library") version "3.5.2" apply false
     id("dev.inkremental.module") version "0.7.1" apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx1024m
 
 GROUP=dev.inkremental
-VERSION_NAME=0.14
+VERSION_NAME=0.15
 
 BINTRAY_REPO=maven
 BINTRAY_ORG=inkremental


### PR DESCRIPTION
Since Kotlin 1.4 introduced binary incompatibility of inline classes, a project that uses Kotlin 1.4 should also have Inkremental version compiled with 1.4